### PR TITLE
Fix for update_patches script

### DIFF
--- a/devutils/update_patches.sh
+++ b/devutils/update_patches.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eux
 
-PLATFORM_ROOT=$(dirname $(greadlink -f ${BASH_SOURCE[0]}))
-UNGOOGLED_REPO=$PLATFORM_ROOT/upstream/ungoogled-chromium
+PLATFORM_ROOT=$(dirname $(dirname $(greadlink -f ${BASH_SOURCE[0]})))
+UNGOOGLED_REPO=$PLATFORM_ROOT/ungoogled-chromium
 
 _command=$1
 


### PR DESCRIPTION
The parent project is imported directly in `ungoogled-chromium`, without the `upstream` directory (intended?).
And we need to go up one level to get the `PLATFORM_ROOT` from devutils. 