### PR TITLE
Added Github CI.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Ungoogled-chromium
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build Chromium
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        name: Clone repository
+        with:
+          submodules: true
+      - name: Install dependencies
+        run: |
+          brew install ninja coreutils readline xz zlib python pyenv
+          pyenv install 2.7.13
+          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+      - name: Build
+        run: |
+          ./build.sh
+      - name: Move artifact
+        run: |
+          cd build
+          mkdir artifact
+          mv *chromium*.dmg artifact/
+
+          cd artifact
+          SUMS=checksums.txt
+          openssl md5 *chromium*.dmg > $SUMS
+          openssl sha1 *chromium*.dmg >> $SUMS
+          openssl sha256 *chromium*.dmg >> $SUMS
+          cat $SUMS
+      - uses: actions/upload-artifact@master
+        name: Upload artifact
+        with:
+          name: Ungoogled-chromium
+          path: build/artifact/


### PR DESCRIPTION
Hey, @Eloston.
What do you think about the Github CI?

I did some tests and found that the chromium can easily be built on the github's servers.
As a start, I decided to choose macOS because the Linux has too many distributions, and the compilation on windows just doesn't work.
[6 hours](https://help.github.com/en/articles/about-github-actions#usage-limits) are more than enough to complete all the necessary processes.
A complete compilation from scratch takes about 3 hours.
After a successful build everyone is able to download an artifact.
I think Github CI will allow us to get rid of waiting for someone to compile and upload the chromium on their own. At the moment we just have to believe that no one has uploaded the infected file. But with automated builds this problem will go away and everyone will get "trusted" binary files.

In the future, we can automate the process of creating the pull requests for the binaries repo.

Github CI is currently available only as a beta, and you have [to sign up](https://github.com/features/actions) your organization for it (it usually takes a few days), or wait until November 13th for Github CI to be released.

![image](https://user-images.githubusercontent.com/4051126/63605978-be213a80-c5d7-11e9-9129-99c2d2b68a0b.png)
![image](https://user-images.githubusercontent.com/4051126/63605992-c5e0df00-c5d7-11e9-8407-3e130daf4fee.png)

https://github.com/23rd/ungoogled-chromium-macos/commit/3f334da6d377abb7285e386d1a7648b90b10386a/checks

