### PR TITLE
README: Update instruction compatible with Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A `.dmg` should appear in `build/`
 1. Start the process and set the environment variables
 ```sh
 ./devutils/update_patches.sh merge
+bash 
 source devutils/set_quilt_vars.sh
 ```
 


### PR DESCRIPTION
Update instructions for macOS Catalina. 
zsh is the new default shell, launching a bash subshell will always work, regardless of the macOS release we are using.