### PR TITLE
Force macOS 10.14 for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build Chromium
-    runs-on: macos-latest
+    runs-on: macOS-10.14
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
At the moment this appears to work, don't know for how long they will keep 10.14 around.
Temporarily fixes #37. 