### PR TITLE
Update ungoogled-chromium to 80.0.3987.87-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ macOS packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium
 * Perl (for creating a `.dmg` package)
 * Python 2, specifically 2.7.13 or newer, as `python` in PATH
 * Python 3.5 or newer as `python3` in PATH
+* Node.js
 
 ### Setting up the build environment
 
@@ -35,7 +36,8 @@ macOS packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium
 echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
 ```
 8. Set global `python` command to use Python 2.7.13: `pyenv global 2.7.13`.
-9. Restart your Terminal
+9. Install Node.js: `brew install node`
+10. Restart your Terminal
 
 ### Build
 

--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -9,5 +9,4 @@ is_official_build=true
 proprietary_codecs=true
 symbol_level=0
 use_gnome_keyring=false
-use_jumbo_build=true
 use_sysroot=false

--- a/patches/debian_buster/disable/installer.patch
+++ b/patches/debian_buster/disable/installer.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/BUILD.gn
 +++ b/BUILD.gn
-@@ -67,8 +67,6 @@ group("gn_all") {
+@@ -68,8 +68,6 @@ group("gn_all") {
      "//base:base_perftests",
      "//base:base_unittests",
      "//base/util:base_util_unittests",

--- a/patches/debian_buster/fixes/as-needed.patch
+++ b/patches/debian_buster/fixes/as-needed.patch
@@ -3,7 +3,7 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -401,7 +401,7 @@ config("compiler") {
+@@ -406,7 +406,7 @@ config("compiler") {
      if (!using_sanitizer) {
        ldflags += [
          "-Wl,-z,defs",

--- a/patches/debian_buster/fixes/mojo.patch
+++ b/patches/debian_buster/fixes/mojo.patch
@@ -3,19 +3,18 @@ author: Michael Gilbert <mgilbert@debian.org>
 
 --- a/content/shell/BUILD.gn
 +++ b/content/shell/BUILD.gn
-@@ -297,11 +297,7 @@ jumbo_static_library("content_shell_lib"
+@@ -300,10 +300,7 @@ jumbo_static_library("content_shell_lib"
      "//content/public/common",
      "//content/public/common:service_names",
      "//content/shell/test_runner:test_runner",
 -    "//content/test:content_test_mojo_bindings",
 -    "//content/test:mojo_web_test_bindings",
--    "//content/test:mojo_web_test_old_names_bindings",
      "//content/test:test_support",
 -    "//content/test:web_test_support",
      "//device/bluetooth",
      "//device/bluetooth:fake_bluetooth",
      "//device/bluetooth:mocks",
-@@ -361,7 +357,7 @@ jumbo_static_library("content_shell_lib"
+@@ -363,7 +360,7 @@ jumbo_static_library("content_shell_lib"
    }
  
    # Annoyingly, this target and web_test_support have circular includes.

--- a/patches/debian_buster/fixes/namespace.patch
+++ b/patches/debian_buster/fixes/namespace.patch
@@ -15,30 +15,3 @@ author: Michael Gilbert <mgilbert@debian.org>
 +}
  
  #endif  // CHROME_BROWSER_APPS_PLATFORM_APPS_API_SYNC_FILE_SYSTEM_EXTENSION_SYNC_EVENT_OBSERVER_H_
---- a/chrome/browser/ui/views/confirm_bubble_views.cc
-+++ b/chrome/browser/ui/views/confirm_bubble_views.cc
-@@ -25,6 +25,7 @@
- #include "ui/views/style/typography.h"
- #include "ui/views/widget/widget.h"
- 
-+namespace confirm_bubble_views {
- namespace {
- 
- std::unique_ptr<views::View> CreateExtraView(views::ButtonListener* listener) {
-@@ -36,6 +37,7 @@ std::unique_ptr<views::View> CreateExtra
- }
- 
- }  // namespace
-+}  // namespace confirm_bubble_views
- 
- ConfirmBubbleViews::ConfirmBubbleViews(
-     std::unique_ptr<ConfirmBubbleModel> model)
-@@ -46,7 +48,7 @@ ConfirmBubbleViews::ConfirmBubbleViews(
-   DialogDelegate::set_button_label(
-       ui::DIALOG_BUTTON_CANCEL,
-       model_->GetButtonLabel(ConfirmBubbleModel::BUTTON_CANCEL));
--  help_button_ = DialogDelegate::SetExtraView(::CreateExtraView(this));
-+  help_button_ = DialogDelegate::SetExtraView(confirm_bubble_views::CreateExtraView(this));
- 
-   set_margins(ChromeLayoutProvider::Get()->GetDialogInsetsForContentType(
-       views::TEXT, views::TEXT));

--- a/patches/debian_buster/warnings/int-in-bool-context.patch
+++ b/patches/debian_buster/warnings/int-in-bool-context.patch
@@ -14,7 +14,7 @@ author: Michael Gilbert <mgilbert@debian.org>
          filter_->CopyMem16x16(mb_src, stride_src, mb_dst, stride_dst);
 --- a/gpu/command_buffer/service/gles2_cmd_decoder.cc
 +++ b/gpu/command_buffer/service/gles2_cmd_decoder.cc
-@@ -16052,7 +16052,8 @@ bool GLES2DecoderImpl::GetUniformSetup(G
+@@ -16381,7 +16381,8 @@ bool GLES2DecoderImpl::GetUniformSetup(G
    }
    uint32_t checked_size = 0;
    if (!SizedResult<T>::ComputeSize(num_elements).AssignIfValid(&checked_size)) {
@@ -26,7 +26,7 @@ author: Michael Gilbert <mgilbert@debian.org>
    if (!result) {
 --- a/content/browser/renderer_host/render_widget_host_view_base.cc
 +++ b/content/browser/renderer_host/render_widget_host_view_base.cc
-@@ -308,15 +308,16 @@ void RenderWidgetHostViewBase::SetBackgr
+@@ -307,15 +307,16 @@ void RenderWidgetHostViewBase::SetBackgr
    if (default_background_color_ == color)
      return;
  
@@ -51,10 +51,10 @@ author: Michael Gilbert <mgilbert@debian.org>
  }
 --- a/third_party/blink/renderer/core/html/parser/html_tree_builder.cc
 +++ b/third_party/blink/renderer/core/html/parser/html_tree_builder.cc
-@@ -939,7 +939,7 @@ void HTMLTreeBuilder::ProcessStartTagFor
+@@ -978,7 +978,7 @@ void HTMLTreeBuilder::ProcessStartTagFor
    }
-   if (token->GetName() == kColTag) {
-     ProcessFakeStartTag(kColgroupTag);
+   if (token->GetName() == html_names::kColTag) {
+     ProcessFakeStartTag(html_names::kColgroupTag);
 -    DCHECK(kInColumnGroupMode);
 +    DCHECK_EQ(GetInsertionMode(), kInColumnGroupMode);
      ProcessStartTag(token);

--- a/patches/debian_buster/warnings/printf.patch
+++ b/patches/debian_buster/warnings/printf.patch
@@ -14,7 +14,7 @@ author: Michael Gilbert <mgilbert@debian.org>
  }  // namespace IPC
 --- a/content/browser/web_package/signed_exchange_handler.cc
 +++ b/content/browser/web_package/signed_exchange_handler.cc
-@@ -611,7 +611,7 @@ void SignedExchangeHandler::OnVerifyCert
+@@ -607,7 +607,7 @@ void SignedExchangeHandler::OnVerifyCert
        error_message = base::StringPrintf(
            "CT verification failed. result: %s, policy compliance: %d",
            net::ErrorToShortString(error_code).c_str(),
@@ -25,7 +25,7 @@ author: Michael Gilbert <mgilbert@debian.org>
        error_message =
 --- a/third_party/blink/renderer/modules/cache_storage/inspector_cache_storage_agent.cc
 +++ b/third_party/blink/renderer/modules/cache_storage/inspector_cache_storage_agent.cc
-@@ -450,7 +450,7 @@ class CachedResponseFileReaderLoaderClie
+@@ -453,7 +453,7 @@ class CachedResponseFileReaderLoaderClie
  
    void DidFail(FileErrorCode error) override {
      callback_->sendFailure(ProtocolResponse::Error(String::Format(
@@ -34,14 +34,3 @@ author: Michael Gilbert <mgilbert@debian.org>
      dispose();
    }
  
---- a/net/proxy_resolution/proxy_resolver_v8_tracing.cc
-+++ b/net/proxy_resolution/proxy_resolver_v8_tracing.cc
-@@ -837,7 +837,7 @@ void Job::SaveDnsToLocalCache(const std:
- 
- std::string Job::MakeDnsCacheKey(const std::string& host,
-                                  ProxyResolveDnsOperation op) {
--  return base::StringPrintf("%d:%s", op, host.c_str());
-+  return base::StringPrintf("%d:%s", static_cast<int>(op), host.c_str());
- }
- 
- void Job::HandleAlertOrError(bool is_alert,

--- a/patches/inox-patchset/fix-cfi-failures-with-unbundled-libxml.patch
+++ b/patches/inox-patchset/fix-cfi-failures-with-unbundled-libxml.patch
@@ -1,6 +1,6 @@
 --- a/third_party/blink/renderer/core/xml/parser/xml_document_parser.cc
 +++ b/third_party/blink/renderer/core/xml/parser/xml_document_parser.cc
-@@ -139,11 +139,11 @@ class PendingStartElementNSCallback fina
+@@ -137,11 +137,11 @@ class PendingStartElementNSCallback fina
          attribute_count_(attribute_count),
          defaulted_count_(defaulted_count) {
      namespaces_ = static_cast<xmlChar**>(
@@ -14,7 +14,7 @@
      for (int i = 0; i < attribute_count; ++i) {
        // Each attribute has 5 elements in the array:
        // name, prefix, uri, value and an end pointer.
-@@ -158,12 +158,12 @@ class PendingStartElementNSCallback fina
+@@ -156,12 +156,12 @@ class PendingStartElementNSCallback fina
  
    ~PendingStartElementNSCallback() override {
      for (int i = 0; i < namespace_count_ * 2; ++i)
@@ -31,7 +31,7 @@
    }
  
    void Call(XMLDocumentParser* parser) override {
-@@ -205,7 +205,7 @@ class PendingCharactersCallback final
+@@ -203,7 +203,7 @@ class PendingCharactersCallback final
    PendingCharactersCallback(const xmlChar* chars, int length)
        : chars_(xmlStrndup(chars, length)), length_(length) {}
  
@@ -40,7 +40,7 @@
  
    void Call(XMLDocumentParser* parser) override {
      parser->Characters(chars_, length_);
-@@ -281,7 +281,7 @@ class PendingErrorCallback final : publi
+@@ -279,7 +279,7 @@ class PendingErrorCallback final : publi
          line_number_(line_number),
          column_number_(column_number) {}
  
@@ -125,15 +125,4 @@
 +      free(results_tab[j]);
      }
    }
- 
---- a/third_party/libxml/chromium/libxml_utils.cc
-+++ b/third_party/libxml/chromium/libxml_utils.cc
-@@ -23,7 +23,7 @@ std::string XmlStringToStdString(const x
- // Same as XmlStringToStdString but also frees |xmlstring|.
- std::string XmlStringToStdStringWithDelete(xmlChar* xmlstring) {
-   std::string result = XmlStringToStdString(xmlstring);
--  xmlFree(xmlstring);
-+  free(xmlstring);
-   return result;
- }
  

--- a/patches/series
+++ b/patches/series
@@ -17,3 +17,4 @@ ungoogled-chromium/macos/fix-visibility.patch
 ungoogled-chromium/macos/fix-older-sdk-declarations.patch
 ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch
 ungoogled-chromium/macos/fix-dsymutil.patch
+ungoogled-chromium/fix-node-path.patch

--- a/patches/ungoogled-chromium/fix-node-path.patch
+++ b/patches/ungoogled-chromium/fix-node-path.patch
@@ -1,0 +1,20 @@
+--- a/third_party/node/node.py
++++ b/third_party/node/node.py
+@@ -10,11 +10,12 @@ import sys
+ 
+ 
+ def GetBinaryPath():
+-  return os_path.join(os_path.dirname(__file__), *{
+-    'Darwin': ('mac', 'node-darwin-x64', 'bin', 'node'),
+-    'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
+-    'Windows': ('win', 'node.exe'),
+-  }[platform.system()])
++  return subprocess.check_output(["which", "node"]).strip()
++#  return os_path.join(os_path.dirname(__file__), *{
++#    'Darwin': ('mac', 'node-darwin-x64', 'bin', 'node'),
++#    'Linux': ('linux', 'node-linux-x64', 'bin', 'node'),
++#    'Windows': ('win', 'node.exe'),
++#  }[platform.system()])
+ 
+ 
+ def RunNode(cmd_parts, stdout=None):

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1238,7 +1238,7 @@ if (is_win) {
+@@ -1246,7 +1246,7 @@ if (is_win) {
    assert(_framework_binary_path != "",
           "Ignore configuration-dependent unused variable warning")
  

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1850,7 +1850,6 @@ jumbo_static_library("browser") {
+@@ -1927,7 +1927,6 @@ jumbo_static_library("browser") {
    allow_circular_includes_from = [
      "//chrome/browser/ui",
      "//chrome/browser/ui/webui/bluetooth_internals",
@@ -10,15 +10,15 @@
    ]
  
    public_deps = [
-@@ -1900,7 +1899,6 @@ jumbo_static_library("browser") {
-     "//chrome/browser/push_messaging:budget_proto",
+@@ -1981,7 +1980,6 @@ jumbo_static_library("browser") {
+     "//chrome/browser/reputation:proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
 -    "//chrome/browser/safe_browsing",
-     "//chrome/browser/sharing/proto",
      "//chrome/browser/ssl:proto",
      "//chrome/browser/touch_to_fill",
-@@ -4085,13 +4083,6 @@ jumbo_static_library("browser") {
+     "//chrome/browser/ui",
+@@ -4223,13 +4221,6 @@ jumbo_static_library("browser") {
      ]
    }
  
@@ -34,7 +34,7 @@
        "crash_upload_list/crash_upload_list_crashpad.cc",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -747,9 +747,6 @@ jumbo_static_library("extensions") {
+@@ -752,9 +752,6 @@ jumbo_static_library("extensions") {
  
      # TODO(loyso): Remove this circular dependency. http://crbug.com/876576.
      "//chrome/browser/web_applications/extensions",
@@ -44,7 +44,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -761,9 +758,7 @@ jumbo_static_library("extensions") {
+@@ -766,9 +763,7 @@ jumbo_static_library("extensions") {
      "//chrome/browser/extensions/api:api_registration",
      "//chrome/common",
      "//chrome/common/extensions/api",
@@ -54,7 +54,7 @@
      "//components/signin/core/browser",
      "//content/public/browser",
      "//mojo/public/cpp/bindings",
-@@ -785,7 +780,6 @@ jumbo_static_library("extensions") {
+@@ -791,7 +786,6 @@ jumbo_static_library("extensions") {
      "//chrome/browser/media/router",
      "//chrome/browser/media/router/discovery",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -62,7 +62,7 @@
      "//chrome/browser/web_applications/components",
      "//chrome/browser/web_applications/extensions",
      "//chrome/common/extensions/api:extensions_features",
-@@ -831,11 +825,6 @@ jumbo_static_library("extensions") {
+@@ -837,11 +831,6 @@ jumbo_static_library("extensions") {
      "//components/proxy_config",
      "//components/rappor",
      "//components/resources",
@@ -76,7 +76,7 @@
      "//components/services/unzip/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -341,15 +341,9 @@ jumbo_static_library("ui") {
+@@ -338,15 +338,9 @@ jumbo_static_library("ui") {
      }
    }
  
@@ -93,23 +93,23 @@
    defines = []
    libs = []
  
-@@ -365,7 +359,6 @@ jumbo_static_library("ui") {
-   # browser, then we can clean up these dependencies.
+@@ -363,7 +357,6 @@ jumbo_static_library("ui") {
    public_deps = [
+     "//chrome/common/string_matching",
      "//components/dom_distiller/core",
 -    "//components/safe_browsing:buildflags",
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -395,7 +388,6 @@ jumbo_static_library("ui") {
-     "//chrome/browser/profiling_host",
+@@ -397,7 +390,6 @@ jumbo_static_library("ui") {
      "//chrome/browser/resources/omnibox:resources",
+     "//chrome/browser/resources/quota_internals:quota_internals_resources",
      "//chrome/browser/resources/usb_internals:resources",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/ssl:proto",
      "//chrome/browser/ui/webui/bluetooth_internals",
      "//chrome/browser/ui/webui/downloads:mojo_bindings",
-@@ -474,16 +466,6 @@ jumbo_static_library("ui") {
+@@ -478,16 +470,6 @@ jumbo_static_library("ui") {
      "//components/rappor",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -126,7 +126,7 @@
      "//components/safe_browsing/web_ui",
      "//components/search",
      "//components/search_engines",
-@@ -1362,7 +1344,6 @@ jumbo_static_library("ui") {
+@@ -1393,7 +1375,6 @@ jumbo_static_library("ui") {
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
        "//chrome/browser/resource_coordinator:tab_metrics_event_proto",
        "//chrome/browser/resource_coordinator/tab_ranker",
@@ -134,7 +134,7 @@
        "//chrome/browser/ui/webui/app_management:mojo_bindings",
        "//chrome/common:buildflags",
        "//chrome/common:search_mojom",
-@@ -2409,7 +2390,6 @@ jumbo_static_library("ui") {
+@@ -2458,7 +2439,6 @@ jumbo_static_library("ui") {
        "//ui/views/controls/webview",
      ]
      deps += [
@@ -142,7 +142,7 @@
        "//chrome/browser/ui/startup:buildflags",
        "//chrome/browser/win/conflicts:module_info",
        "//chrome/credential_provider/common:common_constants",
-@@ -3986,15 +3966,6 @@ jumbo_static_library("ui") {
+@@ -4022,15 +4002,6 @@ jumbo_static_library("ui") {
      }
    }
  
@@ -195,7 +195,7 @@
  }
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
-@@ -1327,10 +1327,10 @@ void Browser::OnDidBlockNavigation(conte
+@@ -1355,10 +1355,10 @@ void Browser::OnDidBlockNavigation(conte
        framebust_helper->AddBlockedUrl(blocked_url, base::BindOnce(on_click));
      }
    }
@@ -212,7 +212,7 @@
  content::PictureInPictureResult Browser::EnterPictureInPicture(
 --- a/chrome/browser/safe_browsing/download_protection/check_client_download_request_base.cc
 +++ b/chrome/browser/safe_browsing/download_protection/check_client_download_request_base.cc
-@@ -153,12 +153,20 @@ CheckClientDownloadRequestBase::CheckCli
+@@ -159,12 +159,20 @@ CheckClientDownloadRequestBase::CheckCli
      is_incognito_ = browser_context->IsOffTheRecord();
      is_under_advanced_protection_ =
          profile &&
@@ -235,7 +235,7 @@
          g_browser_process->local_state()->GetInteger(
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -321,8 +321,12 @@ void DownloadProtectionService::ShowDeta
+@@ -323,8 +323,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -274,9 +274,9 @@
  #include "content/public/browser/download_manager.h"
  #include "content/public/browser/url_data_source.h"
  #include "content/public/browser/web_contents.h"
-@@ -56,10 +57,12 @@ content::WebUIDataSource* CreateDownload
-   content::WebUIDataSource* source =
-       content::WebUIDataSource::Create(chrome::kChromeUIDownloadsHost);
+@@ -70,10 +71,12 @@ content::WebUIDataSource* CreateDownload
+       kGeneratedPath, IDR_DOWNLOADS_DOWNLOADS_HTML);
+ #endif
  
 -  bool requests_ap_verdicts =
 -      safe_browsing::AdvancedProtectionStatusManagerFactory::GetForProfile(
@@ -288,10 +288,10 @@
 +  #endif
    source->AddBoolean("requestsApVerdicts", requests_ap_verdicts);
  
-   static constexpr LocalizedString kStrings[] = {
+   static constexpr webui::LocalizedString kStrings[] = {
 --- a/chrome/browser/ui/views/download/download_danger_prompt_views.cc
 +++ b/chrome/browser/ui/views/download/download_danger_prompt_views.cc
-@@ -219,17 +219,18 @@ base::string16 DownloadDangerPromptViews
+@@ -218,17 +218,18 @@ base::string16 DownloadDangerPromptViews
              download_->GetFileNameToReportUser().LossyDisplayName());
        }
        case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
@@ -314,7 +314,7 @@
          return l10n_util::GetStringFUTF16(
 --- a/chrome/browser/ui/views/download/download_item_view.cc
 +++ b/chrome/browser/ui/views/download/download_item_view.cc
-@@ -999,6 +999,7 @@ void DownloadItemView::ShowWarningDialog
+@@ -1062,6 +1062,7 @@ void DownloadItemView::ShowWarningDialog
  gfx::ImageSkia DownloadItemView::GetWarningIcon() {
    switch (model_->GetDangerType()) {
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
@@ -322,7 +322,7 @@
        if (safe_browsing::AdvancedProtectionStatusManagerFactory::GetForProfile(
                model()->profile())
                ->RequestsAdvancedProtectionVerdicts()) {
-@@ -1007,6 +1008,7 @@ gfx::ImageSkia DownloadItemView::GetWarn
+@@ -1070,6 +1071,7 @@ gfx::ImageSkia DownloadItemView::GetWarn
              GetNativeTheme()->GetSystemColor(
                  ui::NativeTheme::kColorId_AlertSeverityMedium));
        }

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -12,12 +12,12 @@
 --- a/build/toolchain/mac/BUILD.gn
 +++ b/build/toolchain/mac/BUILD.gn
 @@ -185,8 +185,7 @@ template("mac_toolchain") {
+     if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
-       if (is_mac) {
-         dsym_switch += "-Wcrl,dsymutilpath," +
--                       rebase_path("//tools/clang/dsymutil/bin/dsymutil",
--                                   root_build_dir) + " "
-+                           "/usr/bin/dsymutil "
-       }
+       dsym_switch += "-Wcrl,dsymutilpath," +
+-                     rebase_path("//tools/clang/dsymutil/bin/dsymutil",
+-                                 root_build_dir) + " "
++                        "/usr/bin/dsymutil "
  
        dsym_output_dir =
+           "{{root_out_dir}}/{{target_output_name}}{{output_extension}}.dSYM"

--- a/patches/ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch
+++ b/patches/ungoogled-chromium/macos/fix-ignored-pragma-optimize.patch
@@ -2,7 +2,7 @@
 
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1511,29 +1511,6 @@ config("default_warnings") {
+@@ -1516,27 +1516,6 @@ config("default_warnings") {
        if (current_toolchain == host_toolchain || !use_xcode_clang) {
          # Flags NaCl (Clang 3.7) and Xcode 9.2 (Clang clang-900.0.39.2) do not
          # recognize.
@@ -14,21 +14,19 @@
 -          # TODO(https://crbug.com/989932): Evaluate and possibly enable.
 -          "-Wno-implicit-int-float-conversion",
 -
--          # TODO(https://crbug.com/999871): Decide if we want to clean up the
--          # codebase or just disable this.  Doesn't seem super useful, but
--          # also fires in only 4 files.
--          "-Wno-c99-designator",
--
--          # This is a side effect of -Wc99-designator; easier to clean up.
--          "-Wno-reorder-init-list",
--
 -          # TODO(https://crbug.com/999886): Clean up, enable.
 -          "-Wno-final-dtor-non-final-class",
 -
--          # TODO(https://crbug.com/1002945): Evaluate and possibly enable.
--          "-Wno-sizeof-array-div",
+-          # TODO(https://crbug.com/1016947) Clean up, enable.
+-          "-Wno-bitwise-conditional-parentheses",
+-
+-          # TODO(https://crbug.com/1016945) Clean up, enable.
+-          "-Wno-builtin-assume-aligned-alignment",
+-
+-          # TODO(https://crbug.com/1028110): Evaluate and possible enable.
+-          "-Wno-deprecated-copy",
 -        ]
 -
-         cflags_c += [
-           # TODO(https://crbug.com/995993): Clean up and enable.
-           "-Wno-implicit-fallthrough",
+         if (is_fuchsia) {
+           cflags += [
+             # TODO(https://crbug.com/999871): Clean up, enable.


### PR DESCRIPTION
Ungoogled-chromium 80.0.3987.87-1 compiled and is running well.

Notes:
* Node.js is required to build Chromium 80 and the path to the pruned `node` executable is hardcoded. I created a new patch, `fix-node-path.patch` to resolve this issue.
* Jumbo builds are deprecated, so I removed the workarounds that I added to keep jumbo working for v79. Builds take several times as long...
* Chromium 80 can apparently be compiled on Catalina, so the CI runner should work.