### PR TITLE
Update to v111

### DIFF
--- a/patches/ungoogled-chromium/fix-llvm-15-build.patch
+++ b/patches/ungoogled-chromium/fix-llvm-15-build.patch
@@ -1,6 +1,8 @@
+# The second half of this reverts 830fec4889f9c9e3dcdbc29478f668031045f736
+
 --- a/chrome/browser/apps/app_shim/app_shim_manager_mac.cc
 +++ b/chrome/browser/apps/app_shim/app_shim_manager_mac.cc
-@@ -1391,24 +1391,24 @@ std::map<base::FilePath, int> AppShimMan
+@@ -1392,24 +1392,24 @@ std::map<base::FilePath, int> AppShimMan
    // URLs those profiles can handle.
    std::map<base::FilePath, AppShimRegistry::HandlerInfo> handlers =
        AppShimRegistry::Get()->GetHandlersForApp(params.app_id);
@@ -30,3 +32,16 @@
    }
    return result;
  }
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -778,10 +778,6 @@ config("compiler") {
+     ldflags += [ "-Wl,--undefined-version" ]
+   }
+ 
+-  if (use_lld && is_apple) {
+-    ldflags += [ "-Wl,--strict-auto-link" ]
+-  }
+-
+   # LLD does call-graph-sorted binary layout by default when profile data is
+   # present. On Android this increases binary size due to more thinks for long
+   # jumps. Turn it off by default and enable selectively for targets where it's

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1374,7 +1374,7 @@ config("compiler_deterministic") {
+@@ -1402,7 +1402,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -11,12 +11,12 @@
        "--verify-version=$clang_version",
 --- a/build/toolchain/toolchain.gni
 +++ b/build/toolchain/toolchain.gni
-@@ -33,7 +33,7 @@ if (generate_linker_map) {
+@@ -42,7 +42,7 @@ declare_args() {
+     clang_version = "17"
+   } else {
+     # TODO(crbug.com/1410101): Remove in next Clang roll.
+-    clang_version = "16"
++    clang_version = "15"
+   }
  }
  
- declare_args() {
--  clang_version = "16"
-+  clang_version = "15"
- }
- 
- # Extension for shared library files (including leading dot).

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1226,7 +1226,7 @@ if (is_win) {
+@@ -1236,7 +1236,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -3,9 +3,9 @@
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
 @@ -1908,11 +1908,6 @@ static_library("browser") {
-     "//chrome/browser/share",
      "//chrome/browser/ui",
      "//chrome/browser/storage_access_api:permissions",
+     "//chrome/browser/top_level_storage_access_api:permissions",
 -    "//chrome/browser/safe_browsing",
 -    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 -    "//chrome/browser/safe_browsing:advanced_protection",
@@ -14,7 +14,7 @@
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
    ]
-@@ -2012,7 +2007,6 @@ static_library("browser") {
+@@ -2014,7 +2009,6 @@ static_library("browser") {
      "//chrome/browser/push_messaging:budget_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
@@ -24,7 +24,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -731,9 +731,6 @@ static_library("extensions") {
+@@ -733,9 +733,6 @@ static_library("extensions") {
  
      # TODO(crbug.com/1065748): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
@@ -34,7 +34,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -746,8 +743,6 @@ static_library("extensions") {
+@@ -748,8 +745,6 @@ static_library("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -43,7 +43,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -784,7 +779,6 @@ static_library("extensions") {
+@@ -788,7 +783,6 @@ static_library("extensions") {
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:intervention_policy_database_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -51,7 +51,7 @@
      "//chrome/browser/safe_browsing:metrics_collector",
      "//chrome/browser/ui/tabs:tab_enums",
      "//chrome/browser/web_applications",
-@@ -856,12 +850,6 @@ static_library("extensions") {
+@@ -862,12 +856,6 @@ static_library("extensions") {
      "//components/privacy_sandbox:privacy_sandbox_prefs",
      "//components/proxy_config",
      "//components/resources",
@@ -66,8 +66,8 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -371,7 +371,6 @@ static_library("ui") {
-   public_deps = [
+@@ -370,7 +370,6 @@ static_library("ui") {
+     "//chrome/browser/headless",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
 -    "//components/safe_browsing:buildflags",
@@ -81,8 +81,8 @@
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/share",
      "//chrome/browser/ui/webui:configs",
-     "//chrome/browser/ui/webui/bluetooth_internals",
-@@ -553,16 +551,7 @@ static_library("ui") {
+     "//chrome/browser/ui/webui/omnibox:mojo_bindings",
+@@ -554,16 +552,7 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -99,24 +99,24 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -671,7 +660,6 @@ static_library("ui") {
+@@ -672,7 +661,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
 -    "//chrome/browser/safe_browsing",
-     "//chrome/browser/ui/webui/bluetooth_internals",
      "//chrome/browser/profiling_host",
      "//chrome/browser/ui/webui:configs",
-@@ -1790,8 +1778,6 @@ static_library("ui") {
-       "//chrome/browser/resource_coordinator/tab_ranker",
+   ]
+@@ -1778,8 +1766,6 @@ static_library("ui") {
        "//chrome/browser/resources/identity_internals:resources",
        "//chrome/browser/resources/support_tool:resources",
+       "//chrome/browser/resources/web_app_internals:resources",
 -      "//chrome/browser/safe_browsing",
 -      "//chrome/browser/safe_browsing:advanced_protection",
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -3983,7 +3969,6 @@ static_library("ui") {
+@@ -4026,7 +4012,6 @@ static_library("ui") {
      ]
      deps += [
        "//chrome/browser:titlebar_config",
@@ -124,7 +124,7 @@
        "//chrome/browser/ui/startup:buildflags",
        "//chrome/browser/win/conflicts:module_info",
        "//chrome/credential_provider/common:common_constants",
-@@ -5776,26 +5761,6 @@ static_library("ui") {
+@@ -5847,26 +5832,6 @@ static_library("ui") {
      }
    }
  
@@ -192,7 +192,7 @@
  #include "content/public/browser/download_manager.h"
  #include "content/public/browser/url_data_source.h"
  #include "content/public/browser/web_contents.h"
-@@ -63,10 +64,12 @@ content::WebUIDataSource* CreateDownload
+@@ -63,10 +64,12 @@ content::WebUIDataSource* CreateAndAddDo
        source, base::make_span(kDownloadsResources, kDownloadsResourcesSize),
        IDR_DOWNLOADS_DOWNLOADS_HTML);
  
@@ -259,7 +259,7 @@
  }
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6355,9 +6355,6 @@ test("unit_tests") {
+@@ -6307,9 +6307,6 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -11,7 +11,7 @@
      file_match = dsymutil_file_re.search(line)
 --- a/build/toolchain/apple/toolchain.gni
 +++ b/build/toolchain/apple/toolchain.gni
-@@ -245,8 +245,9 @@ template("apple_toolchain") {
+@@ -252,8 +252,9 @@ template("single_apple_toolchain") {
      if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
        dsym_switch += "-Wcrl,dsymutilpath," +


### PR DESCRIPTION
Notes:

- ```fix-llvm-15-build.patch``` has been updated to revert [830fec4](https://chromium-review.googlesource.com/c/chromium/src/+/4189340), as the linker flag added in that commit doesn't exist in LLVM 15.

As a sidenote, it would probably be a good idea to build arm64 binaries here. Creating a tag that contains ```arm``` in its name should do it.