### PR TITLE
CI: Update to macOS 13 and update Xcode to 14.3.1

### DIFF
--- a/.github/scripts/github_disable_spotlight.sh
+++ b/.github/scripts/github_disable_spotlight.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -ux
-sudo mdutil -a -i off
-sudo mdutil -d /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   build_job_01:
     name: Start Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     outputs:
       status: ${{ steps.build.outputs.status }}
 
@@ -38,7 +38,9 @@ jobs:
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable Spotlight
-        run: ./github_disable_spotlight.sh
+        run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Install dependencies
         run: brew install coreutils ninja
       - name: Download, unpack, and prepare for building
@@ -81,7 +83,7 @@ jobs:
   build_job_02:
     continue-on-error: true
     name: Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_01
     if: ${{needs.build_job_01.outputs.status == 'running'}}
     outputs:
@@ -96,6 +98,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download build
         uses: actions/download-artifact@v3
         with:
@@ -142,7 +146,7 @@ jobs:
   build_job_03:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_02
     if: ${{needs.build_job_02.outputs.status == 'running'}}
     outputs:
@@ -157,6 +161,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -203,7 +209,7 @@ jobs:
   build_job_04:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_03
     if: ${{needs.build_job_03.outputs.status == 'running'}}
     outputs:
@@ -218,6 +224,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -264,7 +272,7 @@ jobs:
   build_job_05:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_04
     if: ${{needs.build_job_04.outputs.status == 'running'}}
     outputs:
@@ -279,6 +287,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -325,7 +335,7 @@ jobs:
   build_job_06:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_05
     if: ${{needs.build_job_05.outputs.status == 'running'}}
     outputs:
@@ -340,6 +350,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -386,7 +398,7 @@ jobs:
   build_job_07:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_06
     if: ${{needs.build_job_06.outputs.status == 'running'}}
     outputs:
@@ -401,6 +413,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -447,7 +461,7 @@ jobs:
   build_job_08:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_07
     if: ${{needs.build_job_07.outputs.status == 'running'}}
     outputs:
@@ -462,6 +476,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -508,7 +524,7 @@ jobs:
   build_job_09:
     continue-on-error: true
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-12
+    runs-on: macos-13
     needs: build_job_08
     if: ${{needs.build_job_08.outputs.status == 'running'}}
     outputs:
@@ -523,6 +539,8 @@ jobs:
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable spotlight
         run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Looks like CI successfully failed to build v115. Updating Xcode might solve that issue, since the build works fine locally with Xcode 14.3.1.

Additionally, `github_disable_spotlight.sh` was only being used in the first job, so lets drop it entirely.