### PR TITLE
Update to ungoogled-chromium 116.0.5845.179

### DIFF
--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -1,5 +1,6 @@
 blink_symbol_level=0
 enable_iterator_debugging=false
+enable_mse_mpeg2ts_stream_parser=true
 enable_rust=false
 enable_swiftshader=true
 enable_updater=false
@@ -10,5 +11,4 @@ is_debug=false
 is_official_build=true
 proprietary_codecs=true
 symbol_level=0
-use_gnome_keyring=false
 use_sysroot=false

--- a/patches/ungoogled-chromium/fix-llvm-15-build.patch
+++ b/patches/ungoogled-chromium/fix-llvm-15-build.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/apps/app_shim/app_shim_manager_mac.cc
 +++ b/chrome/browser/apps/app_shim/app_shim_manager_mac.cc
-@@ -1553,24 +1553,24 @@ std::map<base::FilePath, int> AppShimMan
+@@ -1557,24 +1557,24 @@ std::map<base::FilePath, int> AppShimMan
    // URLs those profiles can handle.
    std::map<base::FilePath, AppShimRegistry::HandlerInfo> handlers =
        AppShimRegistry::Get()->GetHandlersForApp(params.app_id);
@@ -32,11 +32,10 @@
  }
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -756,14 +756,6 @@ config("compiler") {
-       }
+@@ -760,13 +760,6 @@ config("compiler") {
  
        ldflags += [ "-Wl,-mllvm,-import-instr-limit=$import_instr_limit" ]
--
+ 
 -      if (!is_chromeos) {
 -        # TODO(https://crbug.com/972449): turn on for ChromeOS when that
 -        # toolchain has this flag.
@@ -47,7 +46,7 @@
      }
  
      # TODO(https://crbug.com/1211155): investigate why this isn't effective on
-@@ -814,10 +806,6 @@ config("compiler") {
+@@ -821,10 +814,6 @@ config("compiler") {
      ldflags += [ "-Wl,--undefined-version" ]
    }
  
@@ -60,7 +59,7 @@
    # jumps. Turn it off by default and enable selectively for targets where it's
 --- a/ui/native_theme/native_theme_aura.cc
 +++ b/ui/native_theme/native_theme_aura.cc
-@@ -117,7 +117,7 @@ SkColor4f NativeThemeAura::FocusRingColo
+@@ -116,7 +116,7 @@ SkColor4f NativeThemeAura::FocusRingColo
  #if BUILDFLAG(IS_APPLE)
    // On Mac OSX, the system Accent Color setting is darkened a bit
    // for better contrast.
@@ -69,17 +68,6 @@
  #else
    return base_color;
  #endif  // BUILDFLAG(IS_APPLE)
---- a/chrome/browser/signin/bound_session_credentials/bound_session_refresh_cookie_fetcher_impl.cc
-+++ b/chrome/browser/signin/bound_session_credentials/bound_session_refresh_cookie_fetcher_impl.cc
-@@ -103,6 +103,6 @@ void BoundSessionRefreshCookieFetcherImp
-   net::Error net_error = static_cast<net::Error>(url_loader_->NetError());
- 
-   std::move(callback_).Run(
--      Result(net_error, headers ? absl::optional<int>(headers->response_code())
--                                : absl::nullopt));
-+      Result({net_error, headers ? absl::optional<int>(headers->response_code())
-+                                : absl::nullopt}));
- }
 --- a/chrome/test/chromedriver/capabilities.cc
 +++ b/chrome/test/chromedriver/capabilities.cc
 @@ -355,7 +355,7 @@ Status ParseMobileEmulation(const base::
@@ -102,7 +90,7 @@
        client_hints.full_version_list = std::move(full_version_list);
 --- a/third_party/blink/renderer/modules/canvas/canvas2d/canvas_style.cc
 +++ b/third_party/blink/renderer/modules/canvas/canvas2d/canvas_style.cc
-@@ -91,12 +91,12 @@ void CanvasStyle::ApplyToFlags(cc::Paint
+@@ -83,12 +83,12 @@ void CanvasStyle::ApplyToFlags(cc::Paint
      case kGradient:
        GetCanvasGradient()->GetGradient()->ApplyToFlags(flags, SkMatrix::I(),
                                                         ImageDrawOptions());
@@ -131,3 +119,104 @@
    }
    std::sort(custom_paper_sizes.begin(), custom_paper_sizes.end(),
              [](const PrinterSemanticCapsAndDefaults::Paper& a,
+--- a/net/dns/host_resolver_cache.cc
++++ b/net/dns/host_resolver_cache.cc
+@@ -159,7 +159,7 @@ void HostResolverCache::Set(
+ 
+   std::string domain_name = result->domain_name();
+   entries_.emplace(
+-      Key(std::move(domain_name), network_anonymization_key),
++      Key({std::move(domain_name), network_anonymization_key}),
+       Entry(std::move(result), source, secure, staleness_generation_));
+ 
+   if (entries_.size() > max_entries_) {
+--- a/components/viz/service/display_embedder/skia_output_surface_impl_on_gpu.cc
++++ b/components/viz/service/display_embedder/skia_output_surface_impl_on_gpu.cc
+@@ -1496,7 +1496,7 @@ void SkiaOutputSurfaceImplOnGpu::CopyOut
+ 
+       // Issue readbacks from the surfaces:
+       for (size_t i = 0; i < CopyOutputResult::kNV12MaxPlanes; ++i) {
+-        SkISize size(plane_surfaces[i]->width(), plane_surfaces[i]->height());
++        SkISize size({plane_surfaces[i]->width(), plane_surfaces[i]->height()});
+         SkImageInfo dst_info = SkImageInfo::Make(
+             size, (i == 0) ? kAlpha_8_SkColorType : kR8G8_unorm_SkColorType,
+             kUnpremul_SkAlphaType);
+--- a/chrome/browser/ui/omnibox/chrome_omnibox_client.cc
++++ b/chrome/browser/ui/omnibox/chrome_omnibox_client.cc
+@@ -470,10 +470,10 @@ void ChromeOmniboxClient::OnAutocomplete
+               alternative_nav_match);
+ 
+   // Store the details necessary to open the omnibox match via browser commands.
+-  location_bar_->set_navigation_params(LocationBar::NavigationParams(
++  location_bar_->set_navigation_params(LocationBar::NavigationParams({
+       destination_url, disposition, transition, match_selection_timestamp,
+       destination_url_entered_without_scheme,
+-      destination_url_entered_with_http_scheme));
++      destination_url_entered_with_http_scheme}));
+ 
+   if (browser_) {
+     auto navigation = chrome::OpenCurrentURL(browser_);
+--- a/content/public/browser/web_ui_browser_interface_broker_registry.h
++++ b/content/public/browser/web_ui_browser_interface_broker_registry.h
+@@ -127,10 +127,11 @@ class CONTENT_EXPORT WebUIBrowserInterfa
+   //
+   // TODO(crbug.com/1407936): Point to WebUIJsBridge documentation.
+   template <typename ControllerType>
++  typename
+   JsBridgeTraits<ControllerType>::BinderInitializer& ForWebUIWithJsBridge() {
+     using Traits = JsBridgeTraits<ControllerType>;
+-    using Interface = Traits::Interface;
+-    using JsBridgeBinderInitializer = Traits::BinderInitializer;
++    using Interface = typename Traits::Interface;
++    using JsBridgeBinderInitializer = typename Traits::BinderInitializer;
+ 
+     // WebUIController::GetType() requires an instantiated WebUIController
+     // (because it's a virtual method and can't be static). Here we only have
+--- a/third_party/blink/renderer/core/paint/object_paint_properties_sparse.h
++++ b/third_party/blink/renderer/core/paint/object_paint_properties_sparse.h
+@@ -269,8 +269,8 @@ class CORE_EXPORT ObjectPaintPropertiesS
+       NodeList& nodes,
+       NodeId node_id,
+       const ParentType& parent,
+-      NodeType::State&& state,
+-      const NodeType::AnimationState& animation_state =
++      typename NodeType::State&& state,
++      const typename NodeType::AnimationState& animation_state =
+           NodeType::AnimationState()) {
+     // First, check if we need to add a new node.
+     if (!nodes.HasField(node_id)) {
+--- a/third_party/blink/renderer/platform/fonts/palette_interpolation.cc
++++ b/third_party/blink/renderer/platform/fonts/palette_interpolation.cc
+@@ -31,7 +31,7 @@ Vector<FontPalette::FontPaletteOverride>
+         color_interpolation_space, hue_interpolation_method, start_color,
+         end_color, percentage, alpha_multiplier);
+ 
+-    FontPalette::FontPaletteOverride result_color_record(i, result_color);
++    FontPalette::FontPaletteOverride result_color_record({static_cast<int>(i), result_color});
+     result_color_records.push_back(result_color_record);
+   }
+   return result_color_records;
+--- a/chrome/browser/content_settings/one_time_permission_provider.cc
++++ b/chrome/browser/content_settings/one_time_permission_provider.cc
+@@ -207,8 +207,8 @@ void OneTimePermissionProvider::OnSuspen
+ 
+       while (rule_iterator && rule_iterator->HasNext()) {
+         auto rule = rule_iterator->Next();
+-        patterns_to_delete.emplace_back(setting_type, rule->primary_pattern,
+-                                        rule->secondary_pattern);
++        patterns_to_delete.emplace_back(ContentSettingEntry{setting_type, rule->primary_pattern,
++                                        rule->secondary_pattern});
+         permissions::PermissionUmaUtil::RecordOneTimePermissionEvent(
+             setting_type,
+             permissions::OneTimePermissionEvent::EXPIRED_ON_SUSPEND);
+@@ -302,8 +302,8 @@ void OneTimePermissionProvider::DeleteEn
+     auto rule = rule_iterator->Next();
+     if (rule->primary_pattern.Matches(origin_gurl) &&
+         rule->secondary_pattern.Matches(origin_gurl)) {
+-      patterns_to_delete.emplace_back(
+-          content_setting_type, rule->primary_pattern, rule->secondary_pattern);
++      patterns_to_delete.emplace_back(ContentSettingEntry{
++          content_setting_type, rule->primary_pattern, rule->secondary_pattern});
+       permissions::PermissionUmaUtil::RecordOneTimePermissionEvent(
+           content_setting_type, trigger_event);
+     }

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1497,7 +1497,7 @@ config("compiler_deterministic") {
+@@ -1511,7 +1511,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,22 +2,21 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1888,11 +1888,6 @@ static_library("browser") {
+@@ -1900,10 +1900,6 @@ static_library("browser") {
      "//chrome/browser/ui",
-     "//chrome/browser/storage_access_api:permissions",
+     "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
 -    "//chrome/browser/safe_browsing",
 -    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 -    "//chrome/browser/safe_browsing:advanced_protection",
 -    "//chrome/browser/safe_browsing:metrics_collector",
--
+ 
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
-   ]
-@@ -1999,7 +1994,6 @@ static_library("browser") {
-     "//chrome/browser/push_messaging:budget_proto",
+@@ -2013,7 +2009,6 @@ static_library("browser") {
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
+     "//chrome/browser/resources/accessibility:resources",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/safe_browsing:advanced_protection",
      "//chrome/browser/safe_browsing:metrics_collector",
@@ -66,7 +65,7 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -475,7 +475,6 @@ static_library("ui") {
+@@ -487,7 +487,6 @@ static_library("ui") {
      "//chrome/browser/headless",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
@@ -74,15 +73,15 @@
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -526,7 +525,6 @@ static_library("ui") {
-     "//chrome/browser/resources/net_internals:resources",
-     "//chrome/browser/resources/omnibox:resources",
-     "//chrome/browser/resources/usb_internals:resources",
+@@ -532,7 +531,6 @@ static_library("ui") {
+     "//chrome/browser/profiling_host",
+     "//chrome/browser/resources:dev_ui_resources",
+     "//chrome/browser/resources:resources",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/share",
+     "//chrome/browser/storage_access_api",
      "//chrome/browser/ui/side_panel:side_panel_enums",
-     "//chrome/browser/ui/webui:configs",
-@@ -662,16 +660,7 @@ static_library("ui") {
+@@ -664,16 +662,7 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -99,7 +98,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -781,7 +770,6 @@ static_library("ui") {
+@@ -782,7 +771,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
@@ -107,16 +106,16 @@
      "//chrome/browser/profiling_host",
      "//chrome/browser/ui/webui:configs",
    ]
-@@ -1923,8 +1911,6 @@ static_library("ui") {
-       "//chrome/browser/resources/identity_internals:resources",
-       "//chrome/browser/resources/support_tool:resources",
-       "//chrome/browser/resources/web_app_internals:resources",
+@@ -1945,8 +1933,6 @@ static_library("ui") {
+       "//chrome/browser/new_tab_page/modules/photos:mojo_bindings",
+       "//chrome/browser/new_tab_page/modules/recipes:mojo_bindings",
+       "//chrome/browser/profile_resetter:profile_reset_report_proto",
 -      "//chrome/browser/safe_browsing",
 -      "//chrome/browser/safe_browsing:advanced_protection",
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -4210,7 +4196,6 @@ static_library("ui") {
+@@ -4227,7 +4213,6 @@ static_library("ui") {
      ]
      deps += [
        "//chrome/browser:titlebar_config",
@@ -124,7 +123,7 @@
        "//chrome/browser/ui/startup:buildflags",
        "//chrome/browser/win/conflicts:module_info",
        "//chrome/credential_provider/common:common_constants",
-@@ -6135,26 +6120,6 @@ static_library("ui") {
+@@ -6190,26 +6175,6 @@ static_library("ui") {
      }
    }
  
@@ -168,7 +167,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -1034,9 +1034,13 @@ std::u16string DownloadItemNotification:
+@@ -1036,9 +1036,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -248,8 +247,8 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6681,13 +6681,9 @@ test("unit_tests") {
-       "//chrome/browser/ui:ui_arc",
+@@ -6696,13 +6696,9 @@ test("unit_tests") {
+       "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
 -      "//chrome/common/safe_browsing:archive_analyzer_results",

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -11,7 +11,7 @@
      file_match = dsymutil_file_re.search(line)
 --- a/build/toolchain/apple/toolchain.gni
 +++ b/build/toolchain/apple/toolchain.gni
-@@ -235,8 +235,9 @@ template("single_apple_toolchain") {
+@@ -238,8 +238,9 @@ template("single_apple_toolchain") {
      if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
        dsym_switch += "-Wcrl,dsymutilpath," +


### PR DESCRIPTION
- Some patch files have been updated to match chromium 116 changes.
- Remove `use_gnome_keyring=false` since it's now unused.
- Add `enable_mse_mpeg2ts_stream_parser=true` to reflect main repo changes ( ungoogled-software/ungoogled-chromium#2471 ).