### PR TITLE
Update to ungoogled-chromium 118.0.5993.88

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,8 +27,8 @@ validate_with_source_task:
             - mkdir chromium_download_cache
             - ./ungoogled-chromium/utils/downloads.py retrieve -i ungoogled-chromium/downloads.ini -c chromium_download_cache
     unpack_source_script:
-        - ./ungoogled-chromium/utils/downloads.py unpack -i ungoogled-chromium/downloads.ini -c chromium_download_cache chromium_src
+        - ./ungoogled-chromium/utils/downloads.py unpack --skip-unused -i ungoogled-chromium/downloads.ini -c chromium_download_cache chromium_src
     validate_patches_script:
-        - ./ungoogled-chromium/devutils/validate_patches.py -l chromium_src -p patches -s patches/series
+        - ./ungoogled-chromium/devutils/validate_patches.py -l chromium_src -v -p patches -s patches/series
 
 # vim: set expandtab shiftwidth=4 softtabstop=4:

--- a/downloads.ini
+++ b/downloads.ini
@@ -14,9 +14,9 @@ output_path = third_party/google_toolbox_for_mac/src
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = 17.0.0
-url = https://github.com/hlgsdx/llvm-macos-buildbot/releases/download/%(version)s-rc4/clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.gz
-download_filename = clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.gz
+version = 17.0.2
+url = https://github.com/hlgsdx/llvm-macos-buildbot/releases/download/%(version)s/clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
+download_filename = clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin22.0
-sha512 = 238a3a6f8e38950251d674e11c5b88bf4b6a21c2a8eab30b8fccea4130b9238157279fb4fb7d8bc2ca356559589178aad28f579d2f96d0b2c62419d1ebf9b175
+sha512 = b0482b7fd2004ac7c09bf18026b786e0f366984fa70efa84a88568a16b414dd6cc7329ce10d96b3df6d6da7edd75ca5a2b310d2878ca1b30054707a61010f6f2
 output_path = third_party/llvm-build/Release+Asserts

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1510,7 +1510,7 @@ config("compiler_deterministic") {
+@@ -1514,7 +1514,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -11,12 +11,12 @@
        "--verify-version=$clang_version",
 --- a/build/toolchain/toolchain.gni
 +++ b/build/toolchain/toolchain.gni
-@@ -38,7 +38,7 @@ if (generate_linker_map) {
- }
+@@ -39,7 +39,7 @@ if (generate_linker_map) {
  
  declare_args() {
--  clang_version = "18"
-+  clang_version = "17"
- }
- 
- # Extension for shared library files (including leading dot).
+   if (llvm_force_head_revision) {
+-    clang_version = "18"
++    clang_version = "17"
+   } else {
+     # TODO(crbug.com/1467585): Remove in the next clang roll
+     clang_version = "17"

--- a/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
+++ b/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
@@ -6,10 +6,10 @@
        const std::map<std::string, std::string>& annotations,
        const std::vector<std::string>& arguments,
        bool restartable) {
--    base::mac::ScopedMachReceiveRight receive_right(
+-    base::apple::ScopedMachReceiveRight receive_right(
 -        NewMachPort(MACH_PORT_RIGHT_RECEIVE));
 -    if (!receive_right.is_valid()) {
--      return base::mac::ScopedMachSendRight();
+-      return base::apple::ScopedMachSendRight();
 -    }
 -
 -    mach_port_t port;
@@ -21,9 +21,9 @@
 -                                               &right_type);
 -    if (kr != KERN_SUCCESS) {
 -      MACH_LOG(ERROR, kr) << "mach_port_extract_right";
--      return base::mac::ScopedMachSendRight();
+-      return base::apple::ScopedMachSendRight();
 -    }
--    base::mac::ScopedMachSendRight send_right(port);
+-    base::apple::ScopedMachSendRight send_right(port);
 -    DCHECK_EQ(port, receive_right.get());
 -    DCHECK_EQ(right_type,
 -              implicit_cast<mach_msg_type_name_t>(MACH_MSG_TYPE_PORT_SEND));
@@ -47,7 +47,7 @@
 -                     std::move(receive_right),
 -                     handler_restarter.get(),
 -                     false)) {
--      return base::mac::ScopedMachSendRight();
+-      return base::apple::ScopedMachSendRight();
 -    }
 -
 -    if (handler_restarter &&
@@ -61,7 +61,7 @@
 -    // handler_restarter will be released when this function returns.
 -
 -    return send_right;
-+  return base::mac::ScopedMachSendRight();
++    return base::apple::ScopedMachSendRight();
    }
  
    // NotifyServer::DefaultInterface:
@@ -72,7 +72,7 @@
 -  // The “restartable” behavior can only be selected on OS X 10.10 and later. In
 -  // previous OS versions, if the initial client were to crash while attempting
 -  // to restart the handler, it would become an unkillable process.
--  base::mac::ScopedMachSendRight exception_port(HandlerStarter::InitialStart(
+-  base::apple::ScopedMachSendRight exception_port(HandlerStarter::InitialStart(
 -      handler,
 -      database,
 -      metrics_dir,

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1298,7 +1298,7 @@ if (is_win) {
+@@ -1294,7 +1294,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1907,10 +1907,6 @@ static_library("browser") {
+@@ -1923,10 +1923,6 @@ static_library("browser") {
      "//chrome/browser/ui",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
@@ -13,7 +13,7 @@
  
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
-@@ -2022,7 +2018,6 @@ static_library("browser") {
+@@ -2039,7 +2035,6 @@ static_library("browser") {
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -746,9 +746,6 @@ static_library("extensions") {
+@@ -759,9 +759,6 @@ static_library("extensions") {
  
      # TODO(crbug.com/1065748): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
@@ -33,7 +33,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -761,8 +758,6 @@ static_library("extensions") {
+@@ -774,8 +771,6 @@ static_library("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,7 +42,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -803,7 +798,6 @@ static_library("extensions") {
+@@ -816,7 +811,6 @@ static_library("extensions") {
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:intervention_policy_database_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -50,7 +50,7 @@
      "//chrome/browser/safe_browsing:metrics_collector",
      "//chrome/browser/ui/tabs:tab_enums",
      "//chrome/browser/web_applications",
-@@ -884,12 +878,6 @@ static_library("extensions") {
+@@ -898,12 +892,6 @@ static_library("extensions") {
      "//components/proxy_config",
      "//components/reading_list/core",
      "//components/resources",
@@ -65,15 +65,15 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -389,7 +389,6 @@ static_library("ui") {
-     "//chrome/browser/headless",
+@@ -392,7 +392,6 @@ static_library("ui") {
+     "//components/cross_device/logging",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
 -    "//components/safe_browsing:buildflags",
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -434,7 +433,6 @@ static_library("ui") {
+@@ -436,7 +435,6 @@ static_library("ui") {
      "//chrome/browser/profiling_host",
      "//chrome/browser/resources:dev_ui_resources",
      "//chrome/browser/resources:resources",
@@ -81,7 +81,7 @@
      "//chrome/browser/share",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/ui/side_panel:side_panel_enums",
-@@ -571,16 +569,7 @@ static_library("ui") {
+@@ -574,17 +572,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -90,6 +90,7 @@
      "//components/safe_browsing/content/browser/web_ui",
 -    "//components/safe_browsing/core/browser/db:database_manager",
 -    "//components/safe_browsing/core/browser/db:util",
+     "//components/safe_browsing/core/browser/hashprefix_realtime:hash_realtime_utils",
 -    "//components/safe_browsing/core/browser/password_protection:password_protection_metrics_util",
 -    "//components/safe_browsing/core/browser/tailored_security_service",
 -    "//components/safe_browsing/core/common",
@@ -98,7 +99,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -689,7 +678,6 @@ static_library("ui") {
+@@ -693,7 +682,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
@@ -106,7 +107,7 @@
      "//chrome/browser/profiling_host",
      "//chrome/browser/ui/webui:configs",
    ]
-@@ -1882,8 +1870,6 @@ static_library("ui") {
+@@ -1887,8 +1875,6 @@ static_library("ui") {
        "//chrome/browser/new_tab_page/modules/recipes:mojo_bindings",
        "//chrome/browser/new_tab_page/modules/v2/history_clusters:mojo_bindings",
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
@@ -115,7 +116,7 @@
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -4268,7 +4254,6 @@ static_library("ui") {
+@@ -4316,7 +4302,6 @@ static_library("ui") {
      ]
      deps += [
        "//chrome/browser:titlebar_config",
@@ -123,7 +124,7 @@
        "//chrome/browser/ui/startup:buildflags",
        "//chrome/browser/win/conflicts:module_info",
        "//chrome/credential_provider/common:common_constants",
-@@ -6277,26 +6262,6 @@ static_library("ui") {
+@@ -6330,26 +6315,6 @@ static_library("ui") {
      }
    }
  
@@ -152,7 +153,7 @@
    }
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -428,8 +428,12 @@ void DownloadProtectionService::ShowDeta
+@@ -434,8 +434,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -167,7 +168,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -983,9 +983,13 @@ std::u16string DownloadItemNotification:
+@@ -996,9 +996,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -247,7 +248,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6873,13 +6873,9 @@ test("unit_tests") {
+@@ -6944,13 +6944,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",


### PR DESCRIPTION
Notes:

- Upgrade the LLVM toolchain to 17.0.2
- Add [New unpack arg to skip unused dirs](https://github.com/ungoogled-software/ungoogled-chromium/commit/30b6f0f4e868a76b12672450ad842b3d871c0f14) and [Verbose patch validation](https://github.com/ungoogled-software/ungoogled-chromium/commit/6e585e2b1c5a16b6236d2f9f827e58f01c61d421) to `.cirrus.yml`

---

Builds and runs fine locally.
<img width="704" alt="Shottr_2023-10-19_21-27-51_spfy" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/20733681/8927c762-4472-4e3f-ad57-14ebf93c8903">
