### PR TITLE
Update to ungoogled-chromium 119.0.6045.159

### DIFF
--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1514,7 +1514,7 @@ config("compiler_deterministic") {
+@@ -1535,7 +1535,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -9,14 +9,3 @@
      update_args = [
        "--print-revision",
        "--verify-version=$clang_version",
---- a/build/toolchain/toolchain.gni
-+++ b/build/toolchain/toolchain.gni
-@@ -39,7 +39,7 @@ if (generate_linker_map) {
- 
- declare_args() {
-   if (llvm_force_head_revision) {
--    clang_version = "18"
-+    clang_version = "17"
-   } else {
-     # TODO(crbug.com/1467585): Remove in the next clang roll
-     clang_version = "17"

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1294,7 +1294,7 @@ if (is_win) {
+@@ -1290,7 +1290,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1923,10 +1923,6 @@ static_library("browser") {
+@@ -1968,10 +1968,6 @@ static_library("browser") {
      "//chrome/browser/ui",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
@@ -13,7 +13,7 @@
  
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
-@@ -2039,7 +2035,6 @@ static_library("browser") {
+@@ -2084,7 +2080,6 @@ static_library("browser") {
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -759,9 +759,6 @@ static_library("extensions") {
+@@ -760,9 +760,6 @@ static_library("extensions") {
  
      # TODO(crbug.com/1065748): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
@@ -33,7 +33,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -774,8 +771,6 @@ static_library("extensions") {
+@@ -775,8 +772,6 @@ static_library("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,7 +42,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -816,7 +811,6 @@ static_library("extensions") {
+@@ -817,7 +812,6 @@ static_library("extensions") {
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:intervention_policy_database_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -50,7 +50,7 @@
      "//chrome/browser/safe_browsing:metrics_collector",
      "//chrome/browser/ui/tabs:tab_enums",
      "//chrome/browser/web_applications",
-@@ -898,12 +892,6 @@ static_library("extensions") {
+@@ -901,12 +895,6 @@ static_library("extensions") {
      "//components/proxy_config",
      "//components/reading_list/core",
      "//components/resources",
@@ -65,7 +65,7 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -392,7 +392,6 @@ static_library("ui") {
+@@ -384,7 +384,6 @@ static_library("ui") {
      "//components/cross_device/logging",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
@@ -73,7 +73,7 @@
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -436,7 +435,6 @@ static_library("ui") {
+@@ -428,7 +427,6 @@ static_library("ui") {
      "//chrome/browser/profiling_host",
      "//chrome/browser/resources:dev_ui_resources",
      "//chrome/browser/resources:resources",
@@ -81,7 +81,7 @@
      "//chrome/browser/share",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/ui/side_panel:side_panel_enums",
-@@ -574,17 +572,8 @@ static_library("ui") {
+@@ -567,17 +565,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -99,7 +99,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -693,7 +682,6 @@ static_library("ui") {
+@@ -686,7 +675,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
@@ -107,7 +107,7 @@
      "//chrome/browser/profiling_host",
      "//chrome/browser/ui/webui:configs",
    ]
-@@ -1887,8 +1875,6 @@ static_library("ui") {
+@@ -1930,8 +1918,6 @@ static_library("ui") {
        "//chrome/browser/new_tab_page/modules/recipes:mojo_bindings",
        "//chrome/browser/new_tab_page/modules/v2/history_clusters:mojo_bindings",
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
@@ -116,15 +116,7 @@
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -4316,7 +4302,6 @@ static_library("ui") {
-     ]
-     deps += [
-       "//chrome/browser:titlebar_config",
--      "//chrome/browser/safe_browsing/chrome_cleaner:public",
-       "//chrome/browser/ui/startup:buildflags",
-       "//chrome/browser/win/conflicts:module_info",
-       "//chrome/credential_provider/common:common_constants",
-@@ -6330,26 +6315,6 @@ static_library("ui") {
+@@ -6442,26 +6428,6 @@ static_library("ui") {
      }
    }
  
@@ -153,7 +145,7 @@
    }
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -434,8 +434,12 @@ void DownloadProtectionService::ShowDeta
+@@ -435,8 +435,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -168,7 +160,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -996,9 +996,13 @@ std::u16string DownloadItemNotification:
+@@ -997,9 +997,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -209,7 +201,7 @@
    static constexpr webui::LocalizedString kStrings[] = {
 --- a/chrome/browser/ui/views/download/download_danger_prompt_views.cc
 +++ b/chrome/browser/ui/views/download/download_danger_prompt_views.cc
-@@ -196,17 +196,18 @@ std::u16string DownloadDangerPromptViews
+@@ -199,17 +199,18 @@ std::u16string DownloadDangerPromptViews
              download_->GetFileNameToReportUser().LossyDisplayName());
        }
        case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
@@ -232,7 +224,7 @@
          return l10n_util::GetStringFUTF16(
 --- a/chrome/browser/ui/views/download/download_item_view.cc
 +++ b/chrome/browser/ui/views/download/download_item_view.cc
-@@ -1019,11 +1019,13 @@ ui::ImageModel DownloadItemView::GetIcon
+@@ -1022,11 +1022,13 @@ ui::ImageModel DownloadItemView::GetIcon
  
    switch (danger_type) {
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
@@ -248,7 +240,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6944,13 +6944,9 @@ test("unit_tests") {
+@@ -7002,13 +7002,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -264,7 +256,7 @@
        # The test fetches resources which means Mac need the app bundle to exist
 --- a/chrome/services/file_util/BUILD.gn
 +++ b/chrome/services/file_util/BUILD.gn
-@@ -40,10 +40,6 @@ source_set("file_util") {
+@@ -42,10 +42,6 @@ source_set("file_util") {
      deps += [ "//components/services/filesystem/public/mojom" ]
    }
  


### PR DESCRIPTION
Notes:
- A submodule bump is made.
- Some patches were refreshed.
	- Two patches were removed as the targeted code from Chromium were removed. (P.S.: This is the first time for me to make these kind of changes, if I made something wrong, please point it out.)

------

Builds and runs fine locally.

<img width="703" alt="image" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/1a1c5db7-a08c-44d1-9ae1-3cfa36846de1">
