### PR TITLE
Fix GitHub Action build failure since 119.0.6045.159

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Install dependencies
         run: brew install coreutils ninja
       - name: Download, unpack, and prepare for building
@@ -98,7 +98,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download build
         uses: actions/download-artifact@v3
         with:
@@ -160,7 +160,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -222,7 +222,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -284,7 +284,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -346,7 +346,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -408,7 +408,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -470,7 +470,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:
@@ -532,7 +532,7 @@ jobs:
       - name: Disable spotlight
         run: sudo mdutil -a -i off
       - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Download resumed build
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Install dependencies
-        run: brew install coreutils ninja
+        # Remove pip call after Chromium 119
+        run: |
+          brew install coreutils ninja
+          pip3 install -U setuptools
       - name: Download, unpack, and prepare for building
         run: ./github_before_build.sh | tee -a github_actions_build.log
       - name: Build


### PR DESCRIPTION
This Pull Request fixes the GitHub Action build failure introduced since #131 (update to Chromium & ungoogled-chromium 119.0.6045.159).