### PR TITLE
Update to ungoogled-chromium 120.0.6099.71

### DIFF
--- a/downloads.ini
+++ b/downloads.ini
@@ -14,11 +14,11 @@ output_path = third_party/google_toolbox_for_mac/src
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = 17.0.2
-url = https://github.com/hlgsdx/llvm-macos-buildbot/releases/download/%(version)s/clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
+version = 17.0.6
+url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s/clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
 download_filename = clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin22.0
-sha512 = b0482b7fd2004ac7c09bf18026b786e0f366984fa70efa84a88568a16b414dd6cc7329ce10d96b3df6d6da7edd75ca5a2b310d2878ca1b30054707a61010f6f2
+sha512 = d9e3b5847a7352020670bec4d12e645e09b9418888eb5f1c720953e500f4e1a71a7a91b7867ea6fbc00d71e1d29374b18a42422866f0750b99d2ba1bdce1a8bd
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs-x64]

--- a/downloads.ini
+++ b/downloads.ini
@@ -20,3 +20,19 @@ download_filename = clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin22.0
 sha512 = b0482b7fd2004ac7c09bf18026b786e0f366984fa70efa84a88568a16b414dd6cc7329ce10d96b3df6d6da7edd75ca5a2b310d2878ca1b30054707a61010f6f2
 output_path = third_party/llvm-build/Release+Asserts
+
+[nodejs-x64]
+version = 16.13.0
+url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
+download_filename = node-v%(version)s-darwin-x64.tar.xz
+strip_leading_dirs = node-v%(version)s-darwin-x64
+sha512=0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6dd243a9ce8633f319fed8e628738094cdd0ff036f4f5cfdf93d46fdc0
+output_path = third_party/node/mac/node-darwin-x64
+
+[nodejs-arm64]
+version = 16.13.0
+url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-arm64.tar.xz
+download_filename = node-v%(version)s-darwin-arm64.tar.xz
+strip_leading_dirs = node-v%(version)s-darwin-arm64
+sha512=8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e31cb1cbb08df78c6ef030a2dff8b9574e8817c74acbcb58a109b5ad9e
+output_path = third_party/node/mac/node-darwin-arm64

--- a/patches/series
+++ b/patches/series
@@ -7,3 +7,4 @@ ungoogled-chromium/macos/fix-clang-format-path.patch
 ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/fix-node-path.patch
 ungoogled-chromium/macos/disable-missing-clang-flags.patch
+ungoogled-chromium/macos/no-unknown-warnings.patch

--- a/patches/series
+++ b/patches/series
@@ -6,3 +6,4 @@ ungoogled-chromium/macos/fix-dsymutil.patch
 ungoogled-chromium/macos/fix-clang-format-path.patch
 ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/fix-node-path.patch
+ungoogled-chromium/macos/disable-missing-clang-flags.patch

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1535,7 +1535,7 @@ config("compiler_deterministic") {
+@@ -1575,7 +1575,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -9,3 +9,14 @@
      update_args = [
        "--print-revision",
        "--verify-version=$clang_version",
+--- a/build/toolchain/toolchain.gni
++++ b/build/toolchain/toolchain.gni
+@@ -47,7 +47,7 @@ declare_args() {
+   if (llvm_android_mainline) {  # https://crbug.com/1481060
+     clang_version = "17"
+   } else {
+-    clang_version = "18"
++    clang_version = "17"
+   }
+ }
+ 

--- a/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
+++ b/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
@@ -2,7 +2,7 @@
 
 --- a/third_party/crashpad/crashpad/client/crashpad_client_mac.cc
 +++ b/third_party/crashpad/crashpad/client/crashpad_client_mac.cc
-@@ -130,61 +130,7 @@ class HandlerStarter final : public Noti
+@@ -131,61 +131,7 @@ class HandlerStarter final : public Noti
        const std::map<std::string, std::string>& annotations,
        const std::vector<std::string>& arguments,
        bool restartable) {
@@ -65,7 +65,7 @@
    }
  
    // NotifyServer::DefaultInterface:
-@@ -455,24 +401,7 @@ bool CrashpadClient::StartHandler(
+@@ -456,24 +402,7 @@ bool CrashpadClient::StartHandler(
    // Attachments are not implemented on MacOS yet.
    DCHECK(attachments.empty());
  

--- a/patches/ungoogled-chromium/macos/disable-missing-clang-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-missing-clang-flags.patch
@@ -1,0 +1,27 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -616,24 +616,6 @@ config("compiler") {
+       }
+     }
+ 
+-    # TODO(crbug.com/1488374): This causes binary size growth and potentially
+-    # other problems.
+-    # TODO(crbug.com/1491036): This isn't supported by Cronet's mainline llvm version.
+-    if (default_toolchain != "//build/toolchain/cros:target" &&
+-        !llvm_android_mainline) {
+-      cflags += [
+-        "-mllvm",
+-        "-split-threshold-for-reg-with-hint=0",
+-      ]
+-      if (use_thin_lto && is_a_target_toolchain) {
+-        if (is_win) {
+-          ldflags += [ "-mllvm:-split-threshold-for-reg-with-hint=0" ]
+-        } else {
+-          ldflags += [ "-Wl,-mllvm,-split-threshold-for-reg-with-hint=0" ]
+-        }
+-      }
+-    }
+-
+     # TODO(crbug.com/1235145): Investigate why/if this should be needed.
+     if (is_win) {
+       cflags += [ "/clang:-ffp-contract=off" ]

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1290,7 +1290,7 @@ if (is_win) {
+@@ -1304,7 +1304,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1968,10 +1968,6 @@ static_library("browser") {
+@@ -1999,10 +1999,6 @@ static_library("browser") {
      "//chrome/browser/ui",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
@@ -13,7 +13,7 @@
  
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
-@@ -2084,7 +2080,6 @@ static_library("browser") {
+@@ -2117,7 +2113,6 @@ static_library("browser") {
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -760,9 +760,6 @@ static_library("extensions") {
+@@ -753,9 +753,6 @@ static_library("extensions") {
  
      # TODO(crbug.com/1065748): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
@@ -33,7 +33,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -775,8 +772,6 @@ static_library("extensions") {
+@@ -768,8 +765,6 @@ static_library("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,15 +42,15 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -817,7 +812,6 @@ static_library("extensions") {
+@@ -809,7 +804,6 @@ static_library("extensions") {
+     "//chrome/browser/profiles",
      "//chrome/browser/profiles:profile",
-     "//chrome/browser/resource_coordinator:intervention_policy_database_proto",
      "//chrome/browser/resource_coordinator:mojo_bindings",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/safe_browsing:metrics_collector",
      "//chrome/browser/ui/tabs:tab_enums",
      "//chrome/browser/web_applications",
-@@ -901,12 +895,6 @@ static_library("extensions") {
+@@ -893,12 +887,6 @@ static_library("extensions") {
      "//components/proxy_config",
      "//components/reading_list/core",
      "//components/resources",
@@ -65,7 +65,7 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -384,7 +384,6 @@ static_library("ui") {
+@@ -388,7 +388,6 @@ static_library("ui") {
      "//components/cross_device/logging",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
@@ -73,7 +73,7 @@
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -428,7 +427,6 @@ static_library("ui") {
+@@ -432,7 +431,6 @@ static_library("ui") {
      "//chrome/browser/profiling_host",
      "//chrome/browser/resources:dev_ui_resources",
      "//chrome/browser/resources:resources",
@@ -81,7 +81,7 @@
      "//chrome/browser/share",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/ui/side_panel:side_panel_enums",
-@@ -567,17 +565,8 @@ static_library("ui") {
+@@ -574,17 +572,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -99,15 +99,15 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -686,7 +675,6 @@ static_library("ui") {
+@@ -693,7 +682,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/profiling_host",
-     "//chrome/browser/ui/webui:configs",
    ]
-@@ -1930,8 +1918,6 @@ static_library("ui") {
+ 
+@@ -1970,8 +1958,6 @@ static_library("ui") {
        "//chrome/browser/new_tab_page/modules/recipes:mojo_bindings",
        "//chrome/browser/new_tab_page/modules/v2/history_clusters:mojo_bindings",
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
@@ -116,7 +116,7 @@
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -6442,26 +6428,6 @@ static_library("ui") {
+@@ -6545,26 +6531,6 @@ static_library("ui") {
      }
    }
  
@@ -145,7 +145,7 @@
    }
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -435,8 +435,12 @@ void DownloadProtectionService::ShowDeta
+@@ -439,8 +439,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -160,7 +160,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -997,9 +997,13 @@ std::u16string DownloadItemNotification:
+@@ -1001,9 +1001,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -240,7 +240,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7002,13 +7002,9 @@ test("unit_tests") {
+@@ -7135,13 +7135,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",

--- a/patches/ungoogled-chromium/macos/no-unknown-warnings.patch
+++ b/patches/ungoogled-chromium/macos/no-unknown-warnings.patch
@@ -1,0 +1,11 @@
+--- a/build/config/mac/BUILD.gn
++++ b/build/config/mac/BUILD.gn
+@@ -52,6 +52,8 @@ config("compiler") {
+   if (export_libcxxabi_from_executables) {
+     ldflags += [ "-Wl,-undefined,dynamic_lookup" ]
+   }
++
++  cflags += [ "-Wno-unknown-warning-option" ]
+ }
+ 
+ # This is included by reference in the //build/config/compiler:runtime_library


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A patch refresh is made.
- The flag changes in [[4903785]](https://chromium-review.googlesource.com/c/chromium/src/+/4903785) were reverted.
- Add a nodejs download.
- Upgrade the LLVM toolchain to 17.0.6
- Suppress unknown warnings (borrowed from [ungoogled-chromium-windows](https://github.com/ungoogled-software/ungoogled-chromium-windows/blob/master/patches/ungoogled-chromium/windows/windows-no-unknown-warnings.patch) 🧐)

------

Builds and runs fine locally.

<img width="685" alt="image" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/f34b78ac-3166-4890-823b-f6f556f11503">

> [!NOTE]
> The error is caused by the Chromium update feature that have been blocked.
