### PR TITLE
ci(build): Use `setup-python` for Python 3.11 setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
         name: Clone repository
         with:
           submodules: true
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
       - name: Disable Spotlight
@@ -43,7 +46,7 @@ jobs:
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Install dependencies
-        run: brew install coreutils ninja python3 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Download, unpack, and prepare for building
         run: ./github_before_build.sh | tee -a github_actions_build.log
       - name: Build


### PR DESCRIPTION
This PR changes the Python setup source of the building GitHub Action from HomeBrew to [actions/setup-python](https://github.com/actions/setup-python) and keeps the Python version at 3.11.

This is a more "permanent" fix to the issue `bs4.FeatureNotFound: Couldn't find a tree builder with the features you requested: html5lib. Do you need to install a parser library?` when building with GitHub CI.

Works in the [forked repo](https://github.com/iXORTech/ungoogled-chromium-macos/actions/runs/7394393860).