### PR TITLE
Update to ungoogled-chromium 121.0.6167.85

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,6 @@ on:
       - '!LICENSE'
       - '!devutils/**'
       - '.github/scripts/force_build.txt'
-  pull_request:
-    paths:
-      - 'patches/**'
-      - 'downloads.ini'
-      - 'revision.txt'
-      - 'flags.macos.gn'
-      - '!build.sh'
-      - '!README.md'
-      - '!LICENSE'
-      - '!devutils/**'
-# alternatively use on.push.branches: release/*
 
 jobs:
   retrieve-resources:

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@ ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/fix-node-path.patch
 ungoogled-chromium/macos/disable-missing-clang-flags.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
+ungoogled-chromium/macos/disable-rust-qr-code-generator.patch

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1575,7 +1575,7 @@ config("compiler_deterministic") {
+@@ -1577,7 +1577,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
+++ b/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
@@ -1,0 +1,82 @@
+--- a/components/qr_code_generator/BUILD.gn
++++ b/components/qr_code_generator/BUILD.gn
+@@ -39,21 +39,11 @@
+   ]
+   deps = [
+     ":qr_code_generator_features",
+-    ":qr_code_generator_ffi_glue",
+     "//base",
+   ]
+   public_deps = [ "//base" ]
+ }
+ 
+-rust_static_library("qr_code_generator_ffi_glue") {
+-  allow_unsafe = true  # Needed for FFI that underpins the `cxx` crate.
+-  crate_root = "qr_code_generator_ffi_glue.rs"
+-  sources = [ "qr_code_generator_ffi_glue.rs" ]
+-  cxx_bindings = [ "qr_code_generator_ffi_glue.rs" ]
+-  visibility = [ ":qr_code_generator" ]
+-  deps = [ "//third_party/rust/qr_code/v2:lib" ]
+-}
+-
+ source_set("unit_tests") {
+   testonly = true
+   sources = [ "qr_code_generator_unittest.cc" ]
+--- a/components/qr_code_generator/qr_code_generator.cc
++++ b/components/qr_code_generator/qr_code_generator.cc
+@@ -11,12 +11,10 @@
+ #include <vector>
+ 
+ #include "base/check_op.h"
+-#include "base/containers/span_rust.h"
+ #include "base/memory/raw_ptr.h"
+ #include "base/notreached.h"
+ #include "base/numerics/safe_conversions.h"
+ #include "components/qr_code_generator/features.h"
+-#include "components/qr_code_generator/qr_code_generator_ffi_glue.rs.h"
+ 
+ namespace qr_code_generator {
+ 
+@@ -572,31 +570,6 @@
+   return sum;
+ }
+ 
+-absl::optional<QRCodeGenerator::GeneratedCode> GenerateQrCodeUsingRust(
+-    base::span<const uint8_t> in,
+-    absl::optional<int> min_version) {
+-  rust::Slice<const uint8_t> rs_in = base::SpanToRustSlice(in);
+-
+-  // `min_version` might come from a fuzzer and therefore we use a lenient
+-  // `saturated_cast` instead of a `checked_cast`.
+-  int16_t rs_min_version =
+-      base::saturated_cast<int16_t>(min_version.value_or(0));
+-
+-  std::vector<uint8_t> result_pixels;
+-  size_t result_width = 0;
+-  bool result_is_success = generate_qr_code_using_rust(
+-      rs_in, rs_min_version, result_pixels, result_width);
+-
+-  if (!result_is_success) {
+-    return absl::nullopt;
+-  }
+-  QRCodeGenerator::GeneratedCode code;
+-  code.data = std::move(result_pixels);
+-  code.qr_size = base::checked_cast<int>(result_width);
+-  CHECK_EQ(code.data.size(), static_cast<size_t>(code.qr_size * code.qr_size));
+-  return code;
+-}
+-
+ }  // namespace
+ 
+ QRCodeGenerator::QRCodeGenerator() = default;
+@@ -617,10 +590,6 @@
+     return absl::nullopt;
+   }
+ 
+-  if (IsRustyQrCodeGeneratorFeatureEnabled()) {
+-    return GenerateQrCodeUsingRust(in, min_version);
+-  }
+-
+   std::vector<Segment> segments;
+   const QRVersionInfo* version_info = nullptr;
+ 

--- a/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
+++ b/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
@@ -79,4 +79,3 @@
 -
    std::vector<Segment> segments;
    const QRVersionInfo* version_info = nullptr;
- 

--- a/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
+++ b/patches/ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
@@ -1,6 +1,6 @@
 --- a/components/qr_code_generator/BUILD.gn
 +++ b/components/qr_code_generator/BUILD.gn
-@@ -39,21 +39,11 @@
+@@ -39,21 +39,11 @@ source_set("qr_code_generator") {
    ]
    deps = [
      ":qr_code_generator_features",
@@ -37,7 +37,7 @@
  
  namespace qr_code_generator {
  
-@@ -572,31 +570,6 @@
+@@ -572,31 +570,6 @@ size_t SegmentSpanLength(base::span<cons
    return sum;
  }
  
@@ -69,7 +69,7 @@
  }  // namespace
  
  QRCodeGenerator::QRCodeGenerator() = default;
-@@ -617,10 +590,6 @@
+@@ -617,10 +590,6 @@ absl::optional<QRCodeGenerator::Generate
      return absl::nullopt;
    }
  
@@ -79,3 +79,4 @@
 -
    std::vector<Segment> segments;
    const QRVersionInfo* version_info = nullptr;
+ 

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1304,7 +1304,7 @@ if (is_win) {
+@@ -1289,7 +1289,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1999,10 +1999,6 @@ static_library("browser") {
+@@ -1967,10 +1967,6 @@ static_library("browser") {
      "//chrome/browser/ui",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
@@ -13,7 +13,7 @@
  
      # TODO(crbug.com/1030821): Eliminate usages of browser.h from Media Router.
      "//chrome/browser/media/router",
-@@ -2117,7 +2113,6 @@ static_library("browser") {
+@@ -2086,7 +2082,6 @@ static_library("browser") {
      "//chrome/browser/resource_coordinator:mojo_bindings",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -753,9 +753,6 @@ static_library("extensions") {
+@@ -747,9 +747,6 @@ static_library("extensions") {
  
      # TODO(crbug.com/1065748): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
@@ -33,7 +33,7 @@
    ]
  
    # Since browser and browser_extensions actually depend on each other,
-@@ -768,8 +765,6 @@ static_library("extensions") {
+@@ -762,8 +759,6 @@ static_library("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,7 +42,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -809,7 +804,6 @@ static_library("extensions") {
+@@ -803,7 +798,6 @@ static_library("extensions") {
      "//chrome/browser/profiles",
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -50,7 +50,7 @@
      "//chrome/browser/safe_browsing:metrics_collector",
      "//chrome/browser/ui/tabs:tab_enums",
      "//chrome/browser/web_applications",
-@@ -893,12 +887,6 @@ static_library("extensions") {
+@@ -888,12 +882,6 @@ static_library("extensions") {
      "//components/proxy_config",
      "//components/reading_list/core",
      "//components/resources",
@@ -65,7 +65,7 @@
      "//components/services/patch/content",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -388,7 +388,6 @@ static_library("ui") {
+@@ -392,7 +392,6 @@ static_library("ui") {
      "//components/cross_device/logging",
      "//components/dom_distiller/core",
      "//components/paint_preview/buildflags",
@@ -73,7 +73,7 @@
      "//components/sync",
      "//components/sync_user_events",
      "//components/translate/content/browser",
-@@ -432,7 +431,6 @@ static_library("ui") {
+@@ -437,7 +436,6 @@ static_library("ui") {
      "//chrome/browser/profiling_host",
      "//chrome/browser/resources:dev_ui_resources",
      "//chrome/browser/resources:resources",
@@ -81,7 +81,7 @@
      "//chrome/browser/share",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/ui/side_panel:side_panel_enums",
-@@ -574,17 +572,8 @@ static_library("ui") {
+@@ -580,17 +578,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -99,7 +99,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -693,7 +682,6 @@ static_library("ui") {
+@@ -703,7 +692,6 @@ static_library("ui") {
      # TODO(crbug.com/1158905): Remove this circular dependency.
      "//chrome/browser/devtools",
      "//chrome/browser/favicon",
@@ -107,16 +107,16 @@
      "//chrome/browser/profiling_host",
    ]
  
-@@ -1970,8 +1958,6 @@ static_library("ui") {
-       "//chrome/browser/new_tab_page/modules/recipes:mojo_bindings",
+@@ -2011,8 +1999,6 @@ static_library("ui") {
        "//chrome/browser/new_tab_page/modules/v2/history_clusters:mojo_bindings",
+       "//chrome/browser/new_tab_page/modules/v2/tab_resumption:mojo_bindings",
        "//chrome/browser/profile_resetter:profile_reset_report_proto",
 -      "//chrome/browser/safe_browsing",
 -      "//chrome/browser/safe_browsing:advanced_protection",
        "//chrome/browser/support_tool:support_tool_proto",
        "//chrome/browser/ui/color:color_headers",
        "//chrome/browser/ui/color:mixers",
-@@ -6545,26 +6531,6 @@ static_library("ui") {
+@@ -6664,26 +6650,6 @@ static_library("ui") {
      }
    }
  
@@ -145,7 +145,7 @@
    }
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -439,8 +439,12 @@ void DownloadProtectionService::ShowDeta
+@@ -453,8 +453,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -160,7 +160,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -1001,9 +1001,13 @@ std::u16string DownloadItemNotification:
+@@ -996,9 +996,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -176,15 +176,15 @@
                ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
 --- a/chrome/browser/ui/webui/downloads/downloads_ui.cc
 +++ b/chrome/browser/ui/webui/downloads/downloads_ui.cc
-@@ -37,6 +37,7 @@
+@@ -39,6 +39,7 @@
  #include "components/history/core/common/pref_names.h"
  #include "components/prefs/pref_service.h"
  #include "components/profile_metrics/browser_profile_type.h"
 +#include "components/safe_browsing/buildflags.h"
  #include "components/safe_browsing/core/common/features.h"
+ #include "components/strings/grit/components_strings.h"
  #include "content/public/browser/download_manager.h"
- #include "content/public/browser/url_data_source.h"
-@@ -64,10 +65,12 @@ content::WebUIDataSource* CreateAndAddDo
+@@ -68,10 +69,12 @@ content::WebUIDataSource* CreateAndAddDo
        source, base::make_span(kDownloadsResources, kDownloadsResourcesSize),
        IDR_DOWNLOADS_DOWNLOADS_HTML);
  
@@ -240,7 +240,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7137,13 +7137,9 @@ test("unit_tests") {
+@@ -7288,13 +7288,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",

--- a/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
+++ b/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
@@ -1,6 +1,6 @@
 --- a/third_party/devtools-frontend/src/third_party/typescript/ts_library.py
 +++ b/third_party/devtools-frontend/src/third_party/typescript/ts_library.py
-@@ -52,7 +52,7 @@ logging.basicConfig(
+@@ -54,7 +54,7 @@ logging.basicConfig(
  
  def runTsc(tsconfig_location):
      cmd = [NODE_LOCATION, TSC_LOCATION, '-p', tsconfig_location]


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A patch refresh is made.
- A patch `ungoogled-chromium/macos/disable-rust-qr-code-generator.patch` is added to revert the Rust QR code generator shipped with [[5064208]](https://chromium-review.googlesource.com/c/chromium/src/+/5064208).

---

Builds and runs fine locally.

![image](https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/ba7fd7b0-0dae-44aa-ae20-33be29332404)
