### PR TITLE
ci: Remove `epoch_finish` timestamp from release & Update actions

### DIFF
--- a/.github/scripts/github_generate_release_note.sh
+++ b/.github/scripts/github_generate_release_note.sh
@@ -5,19 +5,18 @@ _root_dir=$(dirname $(greadlink -f $0))
 _chromium_version=$(cat $_root_dir/ungoogled-chromium/chromium_version.txt)
 _ungoogled_revision=$(cat $_root_dir/ungoogled-chromium/revision.txt)
 _package_revision=$(cat $_root_dir/revision.txt)
-_epoch_finish=$(date +%s)
 
 _x64_hash_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_x86-64-macos.dmg.hashes.md"
 _arm64_hash_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_arm64-macos.dmg.hashes.md"
-_release_tag_version="${_chromium_version}-${_ungoogled_revision}.${_package_revision}__${_epoch_finish}"
+_release_tag_version="${_chromium_version}-${_ungoogled_revision}.${_package_revision}"
 
 _gh_run_href="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
 touch ./github_release_note.md
-printf '## Ungoogled-Chromium %s\n' "$_release_tag_version" | tee -a ./github_release_note.md
-printf '\n' | tee -a ./github_release_note.md
-cat $_x64_hash_name | tee -a ./github_release_note.md
+printf '## Ungoogled-Chromium macOS %s\n' "$_release_tag_version" | tee -a ./github_release_note.md
 printf '\n' | tee -a ./github_release_note.md
 cat $_arm64_hash_name | tee -a ./github_release_note.md
+printf '\n' | tee -a ./github_release_note.md
+cat $_x64_hash_name | tee -a ./github_release_note.md
 printf '\n' | tee -a ./github_release_note.md
 printf 'See [this GitHub Actions Run](%s) for the [Workflow file](%s/workflow) used as well as the build logs and artifacts\n' "$_gh_run_href" "$_gh_run_href" | tee -a ./github_release_note.md

--- a/.github/scripts/github_prepare_artifacts.sh
+++ b/.github/scripts/github_prepare_artifacts.sh
@@ -10,7 +10,6 @@ if [[ -f "$_root_dir/build_finished_$_arch.log" ]] ; then
   _chromium_version=$(cat $_root_dir/ungoogled-chromium/chromium_version.txt)
   _ungoogled_revision=$(cat $_root_dir/ungoogled-chromium/revision.txt)
   _package_revision=$(cat $_root_dir/revision.txt)
-  _epoch_finish=$(date +%s)
 
   _cpu=x86-64; grep -qF arm64 "$_src_dir/out/Default/args.gn" && _cpu=arm64
   _file_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_${_cpu}-macos.dmg"

--- a/.github/scripts/github_prepare_release.sh
+++ b/.github/scripts/github_prepare_release.sh
@@ -5,12 +5,11 @@ _root_dir=$(dirname $(greadlink -f $0))
 _chromium_version=$(cat $_root_dir/ungoogled-chromium/chromium_version.txt)
 _ungoogled_revision=$(cat $_root_dir/ungoogled-chromium/revision.txt)
 _package_revision=$(cat $_root_dir/revision.txt)
-_epoch_finish=$(date +%s)
 
 _x64_file_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_x86-64-macos.dmg"
 _arm64_file_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_arm64-macos.dmg"
-_release_tag_version="${_chromium_version}-${_ungoogled_revision}.${_package_revision}__${_epoch_finish}"
-_release_name="Ungoogled-Chromium macOS ${_release_tag_version}"
+_release_tag_version="${_chromium_version}-${_ungoogled_revision}.${_package_revision}"
+_release_name="${_release_tag_version}"
 
 echo "x64_file_name=$_x64_file_name" >> $GITHUB_OUTPUT
 echo "arm64_file_name=$_arm64_file_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Archive resources
         run: ./github_pack_resources.sh | tee -a github_actions_retrieve_resources.log
       - name: Upload resources
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ungoogled_chromium_macos_resources
           path: upload_build_resources/
@@ -76,11 +76,11 @@ jobs:
         id: bake
         run: ./github_prepare_release.sh | tee -a github_actions_release.log
       - name: Get built x86-64 binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ steps.bake.outputs.x64_file_name }}
       - name: Get built arm64 binary
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ steps.bake.outputs.arm64_file_name }}
       - name: List files

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -111,6 +112,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -171,6 +173,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -231,6 +234,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -291,6 +295,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -351,6 +356,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -411,6 +417,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -471,6 +478,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:
@@ -531,6 +539,7 @@ jobs:
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
+          overwrite: true
       - name: Upload logs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -15,7 +15,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -75,7 +75,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -135,7 +135,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -195,7 +195,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -255,7 +255,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -315,7 +315,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -375,7 +375,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -435,7 +435,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder
@@ -495,7 +495,7 @@ jobs:
       status: ${{ steps.build.outputs.status }}
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - name: Copy GitHub specific scripts to git-root folder

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: brew install coreutils ninja --overwrite
       - name: Download resources
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ungoogled_chromium_macos_resources
       - name: Unpack resources
@@ -47,18 +47,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -83,8 +84,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -102,18 +107,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -138,8 +144,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -157,18 +167,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -193,8 +204,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -212,18 +227,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -248,8 +264,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -267,18 +287,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -303,8 +324,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -322,18 +347,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -358,8 +384,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -377,18 +407,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -413,8 +444,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -432,18 +467,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |
@@ -468,8 +504,12 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
       - name: Download resumed build
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
       - name: Set up Python 3.11
@@ -487,18 +527,19 @@ jobs:
         id: bake
         run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
       - name: Upload part build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
           path: upload_part_build/
       - name: Upload logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: github_build_logs
+          name: github_build_logs_${{ inputs.arch }}
           path: upload_logs/
+          overwrite: true
       - name: Upload disk-image and hash file as artifact after build
         if: ${{ steps.build.outputs.status == 'finished' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.bake.outputs.file_name }}
           path: |


### PR DESCRIPTION
This PR contains:

- [x] The removal of `epoch_finish` timestamp from the release (tag, release title, release body) (as discussed in #146).
- [x] Update `@actions/upload-artifact` and `@actions/download-artifact` to `v4` (so Node.js 20 will be used as Node.js 16 used in `v3` is deprecated).
- [x] `@actions/checkout` to `v4` (so Node.js 20 will be used as Node.js 16 used in `v3` is deprecated).
- [X] Update to ungoogled-chromium 121.0.6167.139

> No modification aside from the submodule bump is needed.
>
> ---
>
> Builds and runs fine locally.
>
> <img width="685" alt="SCR-20240203-ihyg" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/837156ea-bbe4-414b-9efe-065f6c12a7db"> 