### PR TITLE
ci: Build arm64 builds on macos-14 (ARM CI hosts)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,12 +49,18 @@ jobs:
     name: Build macOS binaries of Ungoogled Chromium
     strategy:
       matrix:
-        arch: [x86-64, arm64]
+        arch: [arm64, x86-64]
+        include:
+          - arch: arm64
+            os: macos-14
+          - arch: x86-64
+            os: macos-13
       fail-fast: true
       max-parallel: 2
     uses: ./.github/workflows/building.yml
     with:
       arch: ${{ matrix.arch }}
+      os: ${{ matrix.os }}
 
   release:
     needs: build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   retrieve-resources:
     name: Retrieve resources required for building
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -60,7 +60,7 @@ jobs:
     needs: build
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     name: Release macOS binaries of Ungoogled Chromium
-    runs-on: macos-13
+    runs-on: macos-latest
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -8,9 +8,18 @@ on:
         type: string
 
 jobs:
+  get_runs_on:
+    name: Get macOS system required to build
+    runs-on: macos-latest
+    steps:
+      - name: Set runs-on for arm64 builds
+        if: ${{ inputs.arch == 'arm64' }}
+        run: echo "RUNS_ON=macos-14" >> $GITHUB_ENV
+      - name: Set runs-on for non-arm64 builds
+        run: echo "RUNS_ON=macos-13" >> $GITHUB_ENV
   build_job_01:
     name: Start Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
@@ -69,7 +78,7 @@ jobs:
 
   build_job_02:
     name: Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_01
     if: ${{needs.build_job_01.outputs.status == 'running'}}
     outputs:
@@ -130,7 +139,7 @@ jobs:
 
   build_job_03:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_02
     if: ${{needs.build_job_02.outputs.status == 'running'}}
     outputs:
@@ -191,7 +200,7 @@ jobs:
 
   build_job_04:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_03
     if: ${{needs.build_job_03.outputs.status == 'running'}}
     outputs:
@@ -252,7 +261,7 @@ jobs:
 
   build_job_05:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_04
     if: ${{needs.build_job_04.outputs.status == 'running'}}
     outputs:
@@ -313,7 +322,7 @@ jobs:
 
   build_job_06:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_05
     if: ${{needs.build_job_05.outputs.status == 'running'}}
     outputs:
@@ -374,7 +383,7 @@ jobs:
 
   build_job_07:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_06
     if: ${{needs.build_job_06.outputs.status == 'running'}}
     outputs:
@@ -435,7 +444,7 @@ jobs:
 
   build_job_08:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_07
     if: ${{needs.build_job_07.outputs.status == 'running'}}
     outputs:
@@ -496,7 +505,7 @@ jobs:
 
   build_job_09:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: macos-13
+    runs-on: ${{ env.RUNS_ON }}
     needs: build_job_08
     if: ${{needs.build_job_08.outputs.status == 'running'}}
     outputs:

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -6,20 +6,14 @@ on:
       arch:
         required: true
         type: string
+      os:
+        required: true
+        type: string
 
 jobs:
-  get_runs_on:
-    name: Get macOS system required to build
-    runs-on: macos-latest
-    steps:
-      - name: Set runs-on for arm64 builds
-        if: ${{ inputs.arch == 'arm64' }}
-        run: echo "RUNS_ON=macos-14" >> $GITHUB_ENV
-      - name: Set runs-on for non-arm64 builds
-        run: echo "RUNS_ON=macos-13" >> $GITHUB_ENV
   build_job_01:
     name: Start Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
@@ -78,7 +72,7 @@ jobs:
 
   build_job_02:
     name: Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_01
     if: ${{needs.build_job_01.outputs.status == 'running'}}
     outputs:
@@ -139,7 +133,7 @@ jobs:
 
   build_job_03:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_02
     if: ${{needs.build_job_02.outputs.status == 'running'}}
     outputs:
@@ -200,7 +194,7 @@ jobs:
 
   build_job_04:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_03
     if: ${{needs.build_job_03.outputs.status == 'running'}}
     outputs:
@@ -261,7 +255,7 @@ jobs:
 
   build_job_05:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_04
     if: ${{needs.build_job_04.outputs.status == 'running'}}
     outputs:
@@ -322,7 +316,7 @@ jobs:
 
   build_job_06:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_05
     if: ${{needs.build_job_05.outputs.status == 'running'}}
     outputs:
@@ -383,7 +377,7 @@ jobs:
 
   build_job_07:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_06
     if: ${{needs.build_job_06.outputs.status == 'running'}}
     outputs:
@@ -444,7 +438,7 @@ jobs:
 
   build_job_08:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_07
     if: ${{needs.build_job_07.outputs.status == 'running'}}
     outputs:
@@ -505,7 +499,7 @@ jobs:
 
   build_job_09:
     name: Further Resuming Building Ungoogled-Chromium for macOS
-    runs-on: ${{ env.RUNS_ON }}
+    runs-on: ${{ inputs.os }}
     needs: build_job_08
     if: ${{needs.build_job_08.outputs.status == 'running'}}
     outputs:


### PR DESCRIPTION
This PR adds the ability of building our arm64 builds on GitHub's ARM macOS CI hosts to avoid cross-compiling (that is, compiling arm64 codes on x86-64) we're currently doing.

We can expect some build efficiency improvement coming with these changes.