### PR TITLE
Update to ungoogled-chromium 121.0.6167.160

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Generate release note
         run: ./github_generate_release_note.sh | tee -a github_actions_release.log
       - name: Release Ungoogled-Chromium binaries
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
         with:
           body_path: ./github_release_note.md
           draft: false

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -240,7 +240,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7288,13 +7288,9 @@ test("unit_tests") {
+@@ -7285,13 +7285,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A patch refresh is made.
- The action used to release is updated to `softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981` to use Node20 (using a commit SHA because there's no official version release to a tag yet).

---

<img width="715" alt="image" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/b12732fb-d638-42fa-a5e0-469ca930474b">
