### PR TITLE
build: Add arch-specific dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ validate_with_source_task:
         - sort -o flags.merged.gn flags.merged.gn
         - ./ungoogled-chromium/devutils/check_gn_flags.py -f flags.merged.gn
     check_downloads_ini_script:
-        - ./ungoogled-chromium/devutils/check_downloads_ini.py -d ungoogled-chromium/downloads.ini downloads.ini
+        - ./ungoogled-chromium/devutils/check_downloads_ini.py -d ungoogled-chromium/downloads.ini downloads.ini downloads-x86-64.ini downloads-arm64.ini
     check_patch_files_script:
         - ./ungoogled-chromium/devutils/check_patch_files.py -p patches
     merge_patches_script:

--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -15,8 +15,8 @@ rm -rf "$_src_dir/out" || true
 mkdir -p "$_src_dir/out/Default"
 mkdir -p "$_download_cache"
 
-"$_main_repo/utils/downloads.py" retrieve -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache"
-"$_main_repo/utils/downloads.py" unpack -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache" "$_src_dir"
+"$_root_dir/retrieve_and_unpack_resource.sh"
+
 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - 'patches/**'
-      - 'downloads.ini'
+      - 'downloads**.ini'
       - 'revision.txt'
       - 'flags.macos.gn'
       - '!build.sh'

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ source devutils/set_quilt_vars.sh
 2. Setup Chromium source
 ```sh
 mkdir -p build/{src,download_cache}
-./ungoogled-chromium/utils/downloads.py retrieve -i ungoogled-chromium/downloads.ini downloads.ini -c build/download_cache
-./ungoogled-chromium/utils/downloads.py unpack -i ungoogled-chromium/downloads.ini downloads.ini -c build/download_cache build/src
+./retrieve_and_unpack_resource.sh
 cd build/src
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -21,8 +21,8 @@ rm -rf "$_src_dir/out" || true
 mkdir -p "$_src_dir/out/Default"
 mkdir -p "$_download_cache"
 
-"$_main_repo/utils/downloads.py" retrieve -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache"
-"$_main_repo/utils/downloads.py" unpack -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache" "$_src_dir"
+"$_root_dir/retrieve_and_unpack_resource.sh"
+
 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -1,0 +1,18 @@
+# arm64 (Apple Silicon) specific dependencies not included in the main Chromium source archive
+
+# Pre-built LLVM toolchain for convenience
+[llvm]
+version = 18.1.1
+url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s-arm64/clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
+download_filename = clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
+strip_leading_dirs = clang+llvm-%(version)s-arm64-apple-darwin21.0
+sha512 = cac83e7ea93aba6eb9c9f8623ada0b7fcaf9fb8c9fc79e2313be26e8013235a8ed07c0b9e2d2b7f7e86c71c16e407953ad5e4d3304f55024bbb3cf1fe1901806
+output_path = third_party/llvm-build/Release+Asserts
+
+[nodejs]
+version = 16.13.0
+url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-arm64.tar.xz
+download_filename = node-v%(version)s-darwin-arm64.tar.xz
+strip_leading_dirs = node-v%(version)s-darwin-arm64
+sha512=8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e31cb1cbb08df78c6ef030a2dff8b9574e8817c74acbcb58a109b5ad9e
+output_path = third_party/node/mac/node-darwin-arm64

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -1,0 +1,18 @@
+# x86-64 (Intel) specific dependencies not included in the main Chromium source archive
+
+# Pre-built LLVM toolchain for convenience
+[llvm]
+version = 18.1.1
+url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s-x86-64/clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
+download_filename = clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
+strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin21.0
+sha512 = cac83e7ea93aba6eb9c9f8623ada0b7fcaf9fb8c9fc79e2313be26e8013235a8ed07c0b9e2d2b7f7e86c71c16e407953ad5e4d3304f55024bbb3cf1fe1901806
+output_path = third_party/llvm-build/Release+Asserts
+
+[nodejs]
+version = 16.13.0
+url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
+download_filename = node-v%(version)s-darwin-x64.tar.xz
+strip_leading_dirs = node-v%(version)s-darwin-x64
+sha512=0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6dd243a9ce8633f319fed8e628738094cdd0ff036f4f5cfdf93d46fdc0
+output_path = third_party/node/mac/node-darwin-x64

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -6,7 +6,7 @@ version = 18.1.1
 url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s-x86-64/clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin21.0
-sha512 = cac83e7ea93aba6eb9c9f8623ada0b7fcaf9fb8c9fc79e2313be26e8013235a8ed07c0b9e2d2b7f7e86c71c16e407953ad5e4d3304f55024bbb3cf1fe1901806
+sha512 = 6fda58ee638f5335f39d7ef401a2cdbc5ab95389e1a695e4d6538afb8b145f0fda32fd7626bade0e6c640fcb806f960f7366852b601109c4af4abe53f2026e66
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]

--- a/downloads.ini
+++ b/downloads.ini
@@ -1,5 +1,6 @@
 # Extra dependencies not included in the main Chromium source archive
 # For now, the following are from the top level DEPS file which are needed for building to work
+# Check downloads-x86-64.ini and downloads-arm64.ini for the architecture specific dependencies
 
 # Uses configparser.BasicInterpolation interpolation
 
@@ -11,28 +12,3 @@ download_filename = google-toolbox-for-mac-v%(version)s.tar.gz
 strip_leading_dirs = google-toolbox-for-mac-%(version)s
 sha512 = 18e1e8d91869f82c1b4582c60e191a6f946dd9958f1e1279d86259d45589fbceec636f75f939e96b6a85a2fa457d4df2e6b143b44d21feab21700309addca575
 output_path = third_party/google_toolbox_for_mac/src
-
-# Pre-built LLVM toolchain for convenience
-[llvm]
-version = 17.0.6
-url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s/clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
-download_filename = clang+llvm-%(version)s-x86-64-apple-darwin22.0.tar.xz
-strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin22.0
-sha512 = d9e3b5847a7352020670bec4d12e645e09b9418888eb5f1c720953e500f4e1a71a7a91b7867ea6fbc00d71e1d29374b18a42422866f0750b99d2ba1bdce1a8bd
-output_path = third_party/llvm-build/Release+Asserts
-
-[nodejs-x64]
-version = 16.13.0
-url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
-download_filename = node-v%(version)s-darwin-x64.tar.xz
-strip_leading_dirs = node-v%(version)s-darwin-x64
-sha512=0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6dd243a9ce8633f319fed8e628738094cdd0ff036f4f5cfdf93d46fdc0
-output_path = third_party/node/mac/node-darwin-x64
-
-[nodejs-arm64]
-version = 16.13.0
-url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-arm64.tar.xz
-download_filename = node-v%(version)s-darwin-arm64.tar.xz
-strip_leading_dirs = node-v%(version)s-darwin-arm64
-sha512=8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e31cb1cbb08df78c6ef030a2dff8b9574e8817c74acbcb58a109b5ad9e
-output_path = third_party/node/mac/node-darwin-arm64

--- a/patches/series
+++ b/patches/series
@@ -9,3 +9,4 @@ ungoogled-chromium/fix-node-path.patch
 ungoogled-chromium/macos/disable-missing-clang-flags.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
 ungoogled-chromium/macos/disable-rust-qr-code-generator.patch
+ungoogled-chromium/macos/fix-libpng-build.patch

--- a/patches/ungoogled-chromium/macos/fix-libpng-build.patch
+++ b/patches/ungoogled-chromium/macos/fix-libpng-build.patch
@@ -1,0 +1,15 @@
+--- a/third_party/libpng/BUILD.gn
++++ b/third_party/libpng/BUILD.gn
+@@ -101,6 +101,12 @@ source_set("libpng_sources") {
+     cflags += [ "/wd4146" ]
+   }
+ 
++  if (is_apple) {
++    # TODO(crbug.com/41492875): this can be removed once libpng is updated to include
++    # https://github.com/pnggroup/libpng/commit/893b8113f04d408cc6177c6de19c9889a48faa24
++    cflags += [ "-fno-define-target-os-macros" ]
++  }
++
+   if (is_win && is_component_build) {
+     defines += [ "PNG_BUILD_DLL" ]
+   }

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash 
+
+set -eux
+
+# Script to retrieve and unpack resources to build Chromium macOS
+
+_root_dir=$(dirname $(greadlink -f $0))
+_download_cache="$_root_dir/build/download_cache"
+_src_dir="$_root_dir/build/src"
+_main_repo="$_root_dir/ungoogled-chromium"
+
+# Retrieve and unpack general resources
+
+"$_main_repo/utils/downloads.py" retrieve -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache"
+"$_main_repo/utils/downloads.py" unpack -i "$_main_repo/downloads.ini" "$_root_dir/downloads.ini" -c "$_download_cache" "$_src_dir"
+
+# Retrieve and unpack architecture-specific resources
+if [ "$(uname -m)" = "arm64" ]; then
+    # For arm64 (Apple Silicon)
+    "$_main_repo/utils/downloads.py" retrieve -i "$_root_dir/downloads-arm64.ini" -c "$_download_cache"
+    "$_main_repo/utils/downloads.py" unpack -i "$_root_dir/downloads-arm64.ini" -c "$_download_cache" "$_src_dir"
+else
+    # For x86-64 (Intel)
+    "$_main_repo/utils/downloads.py" retrieve -i "$_root_dir/downloads-x86-64.ini" -c "$_download_cache"
+    "$_main_repo/utils/downloads.py" unpack -i "$_root_dir/downloads-x86-64.ini" -c "$_download_cache" "$_src_dir"
+fi


### PR DESCRIPTION
Changes:

- Use arm64 LLVM when building on Apple Silicon (arm64) (resolve #151)
- Bump LLVM to 18 for build