### PR TITLE
Update to ungoogled-chromium 123.0.6312.105

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ A `.dmg` should appear in `build/`
     ```
 
 5. Use `quilt` to refresh all patches: `quilt push -a --refresh`
-   * If an error occurs, go to the next step. Otherwise, skip to Step 5.
+   * If an error occurs, go to the next step. Otherwise, skip to Step 7.
 6. Use `quilt` to fix the broken patch:
     1. Run `quilt push -f`
     2. Edit the broken files as necessary by adding (`quilt edit ...` or `quilt add ...`) or removing (`quilt remove ...`) files as necessary


### PR DESCRIPTION
No modification aside from the submodule bump is needed.

---

Builds and runs fine locally.

![image](https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/c253b6c0-6154-4b7b-a3f9-00c6785d47df)
