### PR TITLE
Fix Ninja Build Issue

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Show ninja version
         run: ninja --version
       - name: Download resources
@@ -134,7 +134,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -195,7 +195,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -256,7 +256,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -317,7 +317,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -378,7 +378,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -439,7 +439,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -500,7 +500,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -561,7 +561,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja@1.11.1 --overwrite
+        run: brew install coreutils ninja --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Show ninja version
         run: ninja --version
       - name: Download resources
@@ -134,7 +134,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -195,7 +195,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -256,7 +256,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -317,7 +317,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -378,7 +378,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -439,7 +439,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -500,7 +500,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
@@ -561,7 +561,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: brew install coreutils ninja --overwrite
+        run: brew install coreutils ninja@1.11.1 --overwrite
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -64,6 +64,8 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: brew install coreutils ninja --overwrite
+      - name: Show ninja version
+        run: ninja --version
       - name: Download resources
         uses: actions/download-artifact@v4
         with:

--- a/patches/series
+++ b/patches/series
@@ -8,3 +8,4 @@ ungoogled-chromium/macos/fix-dsymutil.patch
 ungoogled-chromium/macos/fix-libpng-build.patch
 ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
+ungoogled-chromium/macos/disable-unsupported-ninja-flag.patch

--- a/patches/ungoogled-chromium/macos/disable-unsupported-ninja-flag.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-ninja-flag.patch
@@ -1,0 +1,11 @@
+--- a/tools/gn/bootstrap/bootstrap.py
++++ b/tools/gn/bootstrap/bootstrap.py
+@@ -122,7 +122,7 @@ def main(argv):
+ 
+   shutil.copy2(
+       os.path.join(BOOTSTRAP_DIR, 'last_commit_position.h'), gn_build_dir)
+-  cmd = [ninja_binary, '-C', gn_build_dir, '-w', 'dupbuild=err', 'gn']
++  cmd = [ninja_binary, '-C', gn_build_dir, 'gn']
+   if options.jobs:
+     cmd += ['-j', str(options.jobs)]
+   subprocess.check_call(cmd)


### PR DESCRIPTION
This PR fixes the Ninja Build issues introduced since Ninja 1.12.0, which failed the build CI for 123.0.6312.122 (#161) by simply removing the flag (used by Chromium) that is no longer supported.

I didn't find anything on Vanilla Chromium end on how this issue will be solved by them as of now.