### PR TITLE
Update to ungoogled-chromium 125.0.6422.112

### DIFF
--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -286,27 +286,3 @@
  };
  // clang-format on
  
---- a/chrome/browser/net/profile_network_context_service.cc
-+++ b/chrome/browser/net/profile_network_context_service.cc
-@@ -285,20 +285,7 @@ void UpdateCookieSettings(Profile* profi
- std::unique_ptr<net::ClientCertStore> GetWrappedCertStore(
-     Profile* profile,
-     std::unique_ptr<net::ClientCertStore> platform_store) {
--  if (!profile || !client_certificates::features::
--                      IsManagedClientCertificateForUserEnabled()) {
--    return platform_store;
--  }
--
--  auto* provisioning_service =
--      client_certificates::CertificateProvisioningServiceFactory::GetForProfile(
--          profile);
--  if (!provisioning_service) {
--    return platform_store;
--  }
--
--  return client_certificates::ClientCertificatesService::Create(
--      provisioning_service, std::move(platform_store));
-+  return nullptr;
- }
- #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
- 


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A patch which is not in Ungoogled-Chromium Core is now removed from platform-specific patches.

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>

---

Builds and runs fine locally.

<img width="700" alt="image" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/41690be8-8664-4072-b131-4447ceefc20f">