### PR TITLE
Update to ungoogled-chromium 126.0.6478.126

### DIFF
--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -12,4 +12,3 @@ is_official_build=true
 proprietary_codecs=true
 symbol_level=0
 use_sysroot=false
-use_thin_lto=false

--- a/patches/series
+++ b/patches/series
@@ -9,3 +9,4 @@ ungoogled-chromium/macos/fix-libpng-build.patch
 ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
 ungoogled-chromium/macos/rust-alloc-fix.patch
+ungoogled-chromium/macos/mark-remap_alloc-used.patch

--- a/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
+++ b/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
@@ -1,0 +1,28 @@
+--- a/build/rust/std/remap_alloc.cc
++++ b/build/rust/std/remap_alloc.cc
+@@ -75,7 +75,11 @@
+   __attribute__((visibility("default"))) __attribute__((weak))
+ #endif
+ #else
++#if BUILDFLAG(IS_MAC) && defined(ARCH_CPU_ARM64)
++#define REMAP_ALLOC_ATTRIBUTES __attribute__((used))
++#else
+ #define REMAP_ALLOC_ATTRIBUTES __attribute__((weak))
++#endif
+ #endif  // COMPONENT_BUILD
+ 
+ // This must exist as the stdlib depends on it to prove that we know the
+@@ -85,8 +89,13 @@
+ // Marked as weak as when Rust drives linking it includes this symbol itself,
+ // and we don't want a collision due to C++ being in the same link target, where
+ // C++ causes us to explicitly link in the stdlib and this symbol here.
++#if BUILDFLAG(IS_MAC) && defined(ARCH_CPU_ARM64)
++[[maybe_unused]] __attribute__((
++    used)) unsigned char __rust_no_alloc_shim_is_unstable;
++#else
+ [[maybe_unused]] __attribute__((
+     weak)) unsigned char __rust_no_alloc_shim_is_unstable;
++#endif
+ 
+ REMAP_ALLOC_ATTRIBUTES void* __rust_alloc(size_t size, size_t align) {
+   // This mirrors kMaxSupportedAlignment from


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A permanent fix for https://github.com/ungoogled-software/ungoogled-chromium/pull/2902#issuecomment-2161983232 (3a7cfb62b4c8cd4e017bb686bbad3086828baaee) is added.

---

Builds and runs fine locally.

<img width="700" alt="image" src="https://github.com/ungoogled-software/ungoogled-chromium-macos/assets/72877496/34952c4d-b1d0-4aab-8127-1cf22a6495d4">

---

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>