### PR TITLE
ci: Fix CI for building 127.0.6533.72

### DIFF
--- a/.github/scripts/github_before_build.sh
+++ b/.github/scripts/github_before_build.sh
@@ -22,4 +22,5 @@ cat "$_root_dir/flags.macos.gn" >> "$_src_dir/out/Default/args.gn"
 cd "$_src_dir"
 
 ./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
+./tools/rust/build_bindgen.py
 ./out/Default/gn gen out/Default --fail-on-unused-args

--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -15,10 +15,12 @@ rm -rf "$_src_dir/out" || true
 mkdir -p "$_src_dir/out/Default"
 mkdir -p "$_download_cache"
 
-"$_root_dir/retrieve_and_unpack_resource.sh"
+"$_root_dir/retrieve_and_unpack_resource.sh" -g
 
 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
+
+"$_root_dir/retrieve_and_unpack_resource.sh" -p
 
 rm -rvf "$_download_cache"

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -15,7 +15,7 @@ url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
 download_filename = node-v%(version)s-darwin-x64.tar.xz
 strip_leading_dirs = node-v%(version)s-darwin-x64
 sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6dd243a9ce8633f319fed8e628738094cdd0ff036f4f5cfdf93d46fdc0
-output_path = third_party/node/mac_x64/node-darwin-x64
+output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
 version = 2024-05-07

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -29,7 +29,7 @@ while getopts 'gp' OPTION; do
         else
             # For x86-64 (Intel)
             "$_main_repo/utils/downloads.py" retrieve -i "$_root_dir/downloads-x86-64.ini" -c "$_download_cache"
-            mkdir -p "$_src_dir/third_party/node/mac_x64/node-darwin-x64/"
+            mkdir -p "$_src_dir/third_party/node/mac/node-darwin-x64/"
             "$_main_repo/utils/downloads.py" unpack -i "$_root_dir/downloads-x86-64.ini" -c "$_download_cache" "$_src_dir"
         fi
 


### PR DESCRIPTION
This PR contains some fix that allows out GitHub Action scripts to properly build 127.0.6533.72.

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>