### PR TITLE
ci: Fix disk space issue with arm64 build hosts

### DIFF
--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -24,8 +24,7 @@ mkdir -p "$_download_cache"
 
 if [[ $_target_cpu == "arm64" ]]; then
     "$_root_dir/retrieve_and_unpack_resource.sh" -a arm64 -p
-else
-    "$_root_dir/retrieve_and_unpack_resource.sh" -p
 fi
+"$_root_dir/retrieve_and_unpack_resource.sh" -p
 
 rm -rvf "$_download_cache"

--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eux
 
 # Simple script for downloading and unpacking required resources to build Ungoogled-Chromium macOS binaries on GitHub Actions
+_target_cpu="${1:-x64}"
 
 _root_dir=$(dirname $(greadlink -f $0))
 _download_cache="$_root_dir/build/download_cache"
@@ -21,6 +22,10 @@ mkdir -p "$_download_cache"
 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -p
+if [[ $_target_cpu == "arm64" ]]; then
+    "$_root_dir/retrieve_and_unpack_resource.sh" -a arm64 -p
+else
+    "$_root_dir/retrieve_and_unpack_resource.sh" -p
+fi
 
 rm -rvf "$_download_cache"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         arch: [arm64, x86-64]
         include:
           - arch: arm64
-            os: macos-14
+            os: macos-13
           - arch: x86-64
             os: macos-13
       fail-fast: true

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install coreutils
         run: brew install coreutils
       - name: Download and unpack required resources
-        run: ./github_fetch_resources.sh | tee -a github_actions_retrieve_resources.log
+        run: ./github_fetch_resources.sh ${{ inputs.arch }} | tee -a github_actions_retrieve_resources.log
       - name: List resources
         run: ls -la
       - name: Archive resources


### PR DESCRIPTION
This fixes the issue where the build actions would fail as the arm64 macos-14 hosts of GitHub Actions doesn't provide enough storage space for all compiling resources to be extracted.

As the testing run (https://github.com/iXORTech/ungoogled-chromium-macos/actions/runs/10658219095) is working fine and passed the resources download/extract step, I assume this would work.