### PR TITLE
ci: Cleanup disk space on CI hosts

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -56,6 +58,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -123,6 +127,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -190,6 +196,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -257,6 +265,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -324,6 +334,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -391,6 +403,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -458,6 +472,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -525,6 +541,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff
@@ -592,6 +610,8 @@ jobs:
     steps:
       - name: Cleanup Xcode installations
         run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_15.0.1.app
       - name: Cleanup Xcode Simulators
         run: sudo xcrun simctl delete all
       - name: Cleanup Android Related Stuff

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -15,6 +15,12 @@ jobs:
     name: Retrieve resources required for building
     runs-on: ${{ inputs.os }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -48,6 +54,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -109,6 +121,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -170,6 +188,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -231,6 +255,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -292,6 +322,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -353,6 +389,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -414,6 +456,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -475,6 +523,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
@@ -536,6 +590,12 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_15.0.1.app /Applications/tmp_xcode_15.0.1.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_xcode_15.0.1.app /Applications/Xcode_15.0.1.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR cleans up GitHub Action hosts' disk space by removing unnecessary SDKs, so there are enough space for UGC resources to be downloaded and unpacked for build.

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>