### PR TITLE
Update to ungoogled-chromium 129.0.6668.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,27 @@ macOS packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium
 
 Many people have asked for notarizing (signing) the Ungoogled-Chromium macOS build ([ungoogled-chromium#859](https://github.com/ungoogled-software/ungoogled-chromium/issues/859), [#63](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/63), [#179](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/179)).
 
-As all Ungoogled-Chromium maintainers are maintaining the software on a voluntary basis, we unfortunately do not have the funds for the Apple Developer Program membership, which is required for notarization.
+Now, we've collected enough funds to cover the cost of the Apple Developer Program membership for 2024-2025 membership year, and we will provide notarized builds later this year (around mid-to-end October 2024). We will keep you updated on the progress.
 
-As of now, I, [@Cubik65536](https://github.com/Cubik65536), the maintainer of Ungoogled-Chromium macOS, am seeking sponsors to help me cover the cost of the Apple Developer Program fee. If you're interested in getting the "official" Ungoogled-Chromium macOS build notarized, please consider sponsoring me through [GitHub Sponsors](https://github.com/sponsors/Cubik65536) or [Buy me a Coffee](https://buymeacoffee.com/cubik65536). The progress of the funding can be tracked on [issue #184](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/184).
+## Sponsorship
 
-Note that:
+Thanks to the generous support from the following sponsors:
 
-1. These sponsorship accounts are under the name of `Cubik65536`. All sponsor records (i.e. who’s sponsoring) will be public unless you choose to make it private. When sponsoring, you can leave a message specifying that it is for Ungoogled-Chromium, so you will be able to be credited in a sponsor list in the future.
-2. There are already some other volunteers who have offered notarized builds, and it is worth mentioning that there are no real differences between their build and the "official" build (released under `ungoogled-software` organization), as people behind the `ungoogled-software` organization are also all volunteers.
+- @pascal-giguere (via GitHub Sponsors)
+- @kevingriffin (via GitHub Sponsors)
+- BabyFn0rd (via By Me a Coffee)
+- dasos (via By Me a Coffee)
+- @vinnysaj (via GitHub Sponsors)
+
+which made it possible for us to cover the cost of the Apple Developer Program membership and provide notarized builds of Ungoogled-Chromium macOS. These supports are greatly appreciated!
+
+New sponsors are still very welcomed, as I (@Cubik65536, current maintainer of Ungoogled-Chromium macOS) am still relying on community sponsors to help me cover the cost of the Apple Developer Program fee for future membership years. The progress of the funding for current and next Apple Developer membership year can be tracked on [issue #184](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/184).
+
+Your support will also greatly encourage and motivaes me to continue putting more effort into maintaining and improving Ungoogled-Chromium macOS.
+
+So, please consider sponsoring me through [GitHub Sponsors](https://github.com/sponsors/Cubik65536) or [Buy me a Coffee](https://buymeacoffee.com/cubik65536).
+
+Note that these sponsorship accounts are under the name of `Cubik65536`. All sponsor records (i.e. who’s sponsoring) will be public unless you choose to make it private. When sponsoring, you can leave a message specifying that it is for Ungoogled-Chromium, so you will be able to be credited in a sponsor list in the future.
 
 ## Building
 

--- a/announcements.md
+++ b/announcements.md
@@ -1,10 +1,23 @@
 Many people have asked for notarizing (signing) the Ungoogled-Chromium macOS build ([ungoogled-chromium#859](https://github.com/ungoogled-software/ungoogled-chromium/issues/859), [#63](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/63), [#179](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/179)).
 
-As all Ungoogled-Chromium maintainers are maintaining the software on a voluntary basis, we unfortunately do not have the funds for the Apple Developer Program membership, which is required for notarization.
+Now, we've collected enough funds to cover the cost of the Apple Developer Program membership for 2024-2025 membership year, and we will provide notarized builds later this year (around mid-to-end October 2024). We will keep you updated on the progress.
 
-As of now, I, [@Cubik65536](https://github.com/Cubik65536), the maintainer of Ungoogled-Chromium macOS, am seeking sponsors to help me cover the cost of the Apple Developer Program fee. If you're interested in getting the "official" Ungoogled-Chromium macOS build notarized, please consider sponsoring me through [GitHub Sponsors](https://github.com/sponsors/Cubik65536) or [Buy me a Coffee](https://buymeacoffee.com/cubik65536). The progress of the funding can be tracked on [issue #184](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/184).
+## Sponsorship
 
-Note that:
+Thanks to the generous support from the following sponsors:
 
-1. These sponsorship accounts are under the name of `Cubik65536`. All sponsor records (i.e. who’s sponsoring) will be public unless you choose to make it private. When sponsoring, you can leave a message specifying that it is for Ungoogled-Chromium, so you will be able to be credited in a sponsor list in the future.
-2. There are already some other volunteers who have offered notarized builds, and it is worth mentioning that there are no real differences between their build and the "official" build (released under `ungoogled-software` organization), as people behind the `ungoogled-software` organization are also all volunteers.
+- @pascal-giguere (via GitHub Sponsors)
+- @kevingriffin (via GitHub Sponsors)
+- BabyFn0rd (via By Me a Coffee)
+- dasos (via By Me a Coffee)
+- @vinnysaj (via GitHub Sponsors)
+
+which made it possible for us to cover the cost of the Apple Developer Program membership and provide notarized builds of Ungoogled-Chromium macOS. These supports are greatly appreciated!
+
+New sponsors are still very welcomed, as I (@Cubik65536, current maintainer of Ungoogled-Chromium macOS) am still relying on community sponsors to help me cover the cost of the Apple Developer Program fee for future membership years. The progress of the funding for current and next Apple Developer membership year can be tracked on [issue #184](https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/184).
+
+Your support will also greatly encourage and motivaes me to continue putting more effort into maintaining and improving Ungoogled-Chromium macOS.
+
+So, please consider sponsoring me through [GitHub Sponsors](https://github.com/sponsors/Cubik65536) or [Buy me a Coffee](https://buymeacoffee.com/cubik65536).
+
+Note that these sponsorship accounts are under the name of `Cubik65536`. All sponsor records (i.e. who’s sponsoring) will be public unless you choose to make it private. When sponsoring, you can leave a message specifying that it is for Ungoogled-Chromium, so you will be able to be credited in a sponsor list in the future.

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = 8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2024-06-15
+version = 2024-07-30
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -2,11 +2,11 @@
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = 18.1.7
+version = 19.1.0
 url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s-arm64/clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-arm64-apple-darwin21.0
-sha512 = 62f20152da26d92650a08c207d22f6b3fbec72ee4e8711b4e61d48e02a09f1a19a8ca3937e5786bc54bc71fcfe895ec6b898f0112a1a07753ee8bbebd8a35da5
+sha512 = 14df960c45cc9728a40abf46b4483dc5cbd1a95cd771ab3f7b61b0d0e252833ab1b1d06ac2ae5c8c245568c025cfc9f0e67275c22c9b8ad2ff25015d982becff
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -2,11 +2,11 @@
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = 18.1.7
+version = 19.1.0
 url = https://github.com/iXORTech/llvm-macos-buildbot/releases/download/%(version)s-x86-64/clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin21.0
-sha512 = 15b130f699fcc8014b1fdbba414eda93240efd0f2c6d9debb3d9ff9c2ea94e723ce4f83e0c24aa289df5193acdf8c8f367dcb02aab80c5237f1775e8bb5a90f9
+sha512 = c177ea4d2265d8d03452d88705a12c1c02c05373399a821c50cd4118a60224bcd042935d4deeab0bb601c6a030517fe8607df8129d1f8a285f1865f92a2f6a86
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2024-06-15
+version = 2024-07-30
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/series
+++ b/patches/series
@@ -10,3 +10,4 @@ ungoogled-chromium/macos/fix-libpng-build.patch
 ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
 ungoogled-chromium/macos/mark-remap_alloc-used.patch
+ungoogled-chromium/macos/re2-include-fix

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,8 +1,8 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1605,8 +1605,7 @@ config("compiler_deterministic") {
+@@ -1620,8 +1620,7 @@ config("compiler_deterministic") {
  }
- 
+
  config("clang_revision") {
 -  if (is_clang && clang_base_path == default_clang_base_path &&
 -      current_os != "zos") {
@@ -16,8 +16,8 @@
    if (llvm_android_mainline) {  # https://crbug.com/1481060
      clang_version = "17"
    } else {
--    clang_version = "19"
-+    clang_version = "18"
+-    clang_version = "20"
++    clang_version = "19"
    }
  }
  

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1256,7 +1256,7 @@ if (is_win) {
+@@ -1268,7 +1268,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -252,8 +252,6 @@ clang_lib("compiler_builtins") {
+@@ -247,8 +247,6 @@ clang_lib("compiler_builtins") {
      } else {
        libname = "ios"
      }

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -28,7 +28,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc 1.81.0-nightly (f8e566053 2024-06-14)"
++  rustc_version = "rustc 1.82.0-nightly (612a33f20 2024-07-29)"
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -212,3 +212,24 @@
  #if !BUILDFLAG(IS_ANDROID)
    { key::kLensOverlaySettings,
      lens::prefs::kLensOverlaySettings,
+--- a/chrome/browser/chrome_content_browser_client.cc
++++ b/chrome/browser/chrome_content_browser_client.cc
+@@ -8018,18 +8018,6 @@ bool ChromeContentBrowserClient::SetupEm
+     CHECK(compiler->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
+                                  soda_language_pack_path.value()));
+     return true;
+-  } else if (sandbox_type == sandbox::mojom::Sandbox::kScreenAI) {
+-    // ScreenAI service needs read access to ScreenAI component binary path to
+-    // load it.
+-    base::FilePath screen_ai_binary_path =
+-        screen_ai::ScreenAIInstallState::GetInstance()
+-            ->get_component_binary_path();
+-    if (screen_ai_binary_path.empty()) {
+-      VLOG(1) << "Screen AI component not found.";
+-      return false;
+-    }
+-    return compiler->SetParameter(sandbox::policy::kParamScreenAiComponentPath,
+-                                  screen_ai_binary_path.value());
+   }
+ 
+   return false;

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,8 +2,8 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1989,10 +1989,6 @@ static_library("browser") {
-     "//chrome/browser/ui",
+@@ -1830,10 +1830,6 @@ static_library("browser") {
+     "//chrome/browser/ui/omnibox:impl",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
 -    "//chrome/browser/safe_browsing",
@@ -13,7 +13,7 @@
      "//chrome/browser/ip_protection",
  
      # TODO(crbug.com/40110173): Eliminate usages of browser.h from Media Router.
-@@ -2093,7 +2089,6 @@ static_library("browser") {
+@@ -1937,7 +1933,6 @@ static_library("browser") {
      "//chrome/browser/promos:utils",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -769,9 +769,6 @@ source_set("extensions") {
+@@ -745,9 +745,6 @@ source_set("extensions") {
      # TODO(crbug.com/346472679): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
      # TODO(crbug.com/343037853): Remove this circular dependency.
      "//chrome/browser/themes",
  
-@@ -794,8 +791,6 @@ source_set("extensions") {
+@@ -778,8 +775,6 @@ source_set("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,7 +42,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -844,7 +839,6 @@ source_set("extensions") {
+@@ -834,7 +829,6 @@ source_set("extensions") {
      "//chrome/browser/profiles",
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -52,7 +52,7 @@
      "//chrome/browser/web_applications",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -621,17 +621,8 @@ static_library("ui") {
+@@ -624,17 +624,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -70,15 +70,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -744,7 +735,6 @@ static_library("ui") {
-     # TODO(crbug.com/40161499): Remove this circular dependency.
-     "//chrome/browser/devtools",
-     "//chrome/browser/favicon",
--    "//chrome/browser/safe_browsing",
-     "//chrome/browser/profiling_host",
- 
-     "//chrome/browser/permissions",
-@@ -6785,7 +6775,6 @@ static_library("ui_public_dependencies")
+@@ -6081,7 +6072,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -119,7 +111,7 @@
                ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
 --- a/chrome/browser/ui/webui/downloads/downloads_ui.cc
 +++ b/chrome/browser/ui/webui/downloads/downloads_ui.cc
-@@ -41,6 +41,7 @@
+@@ -46,6 +46,7 @@
  #include "components/history/core/common/pref_names.h"
  #include "components/prefs/pref_service.h"
  #include "components/profile_metrics/browser_profile_type.h"
@@ -127,7 +119,7 @@
  #include "components/safe_browsing/core/common/features.h"
  #include "components/strings/grit/components_strings.h"
  #include "content/public/browser/download_manager.h"
-@@ -70,10 +71,12 @@ content::WebUIDataSource* CreateAndAddDo
+@@ -75,10 +76,12 @@ content::WebUIDataSource* CreateAndAddDo
        source, base::make_span(kDownloadsResources, kDownloadsResourcesSize),
        IDR_DOWNLOADS_DOWNLOADS_HTML);
  
@@ -144,7 +136,7 @@
    static constexpr webui::LocalizedString kStrings[] = {
 --- a/chrome/browser/ui/views/download/download_danger_prompt_views.cc
 +++ b/chrome/browser/ui/views/download/download_danger_prompt_views.cc
-@@ -179,11 +179,15 @@ std::u16string DownloadDangerPromptViews
+@@ -180,11 +180,15 @@ std::u16string DownloadDangerPromptViews
                                          filename);
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
        return l10n_util::GetStringFUTF16(
@@ -179,7 +171,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7304,13 +7304,9 @@ test("unit_tests") {
+@@ -7148,13 +7148,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -208,9 +200,9 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2197,11 +2197,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2210,11 +2210,6 @@ const PolicyToPreferenceMapEntry kSimple
+     base::Value::Type::BOOLEAN },
  #endif
- #endif // BUILDFLAG(CHROME_CERTIFICATE_POLICIES_SUPPORTED)
  
 -#if BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
 -  { key::kProvisionManagedClientCertificateForUser,

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -11,7 +11,7 @@
      file_match = dsymutil_file_re.search(line)
 --- a/build/toolchain/apple/toolchain.gni
 +++ b/build/toolchain/apple/toolchain.gni
-@@ -228,8 +228,9 @@ template("single_apple_toolchain") {
+@@ -229,8 +229,9 @@ template("single_apple_toolchain") {
      if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
        dsym_switch += "-Wcrl,dsymutilpath," +

--- a/patches/ungoogled-chromium/macos/fix-libpng-build.patch
+++ b/patches/ungoogled-chromium/macos/fix-libpng-build.patch
@@ -1,6 +1,6 @@
 --- a/third_party/libpng/BUILD.gn
 +++ b/third_party/libpng/BUILD.gn
-@@ -101,6 +101,12 @@ source_set("libpng_sources") {
+@@ -107,6 +107,12 @@ source_set("libpng_sources") {
      cflags += [ "/wd4146" ]
    }
  

--- a/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
+++ b/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
@@ -1,6 +1,6 @@
 --- a/build/rust/std/remap_alloc.cc
 +++ b/build/rust/std/remap_alloc.cc
-@@ -73,7 +73,11 @@ extern "C" {
+@@ -74,7 +74,11 @@ extern "C" {
    __attribute__((visibility("default"))) __attribute__((weak))
  #endif
  #else
@@ -12,7 +12,7 @@
  #endif  // COMPONENT_BUILD
  
  // This must exist as the stdlib depends on it to prove that we know the
-@@ -83,8 +87,13 @@ extern "C" {
+@@ -84,8 +88,13 @@ extern "C" {
  // Marked as weak as when Rust drives linking it includes this symbol itself,
  // and we don't want a collision due to C++ being in the same link target, where
  // C++ causes us to explicitly link in the stdlib and this symbol here.

--- a/patches/ungoogled-chromium/macos/re2-include-fix
+++ b/patches/ungoogled-chromium/macos/re2-include-fix
@@ -1,0 +1,11 @@
+--- a/third_party/re2/src/re2/re2.h
++++ b/third_party/re2/src/re2/re2.h
+@@ -220,7 +220,7 @@
+ #include "absl/base/call_once.h"
+ #include "absl/strings/string_view.h"
+ #include "absl/types/optional.h"
+-#include "re2/stringpiece.h"
++#include "stringpiece.h"
+ 
+ #if defined(__APPLE__)
+ #include <TargetConditionals.h>

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -47,7 +47,7 @@ while getopts 'gp' OPTION; do
         _rustc_dir="$_rust_dir/rustc"
         _rustc_lib_dir="$_rust_dir/rustc/lib/rustlib/$_rust_name/lib"
 
-        echo "rustc 1.81.0-nightly (f8e566053 2024-06-14)" > "$_rust_flag_file"
+        echo "rustc 1.82.0-nightly (612a33f20 2024-07-29)" > "$_rust_flag_file"
 
         mkdir $_rust_bin_dir
         ln -s "$_rust_dir/rustc/bin/rustc" "$_rust_bin_dir/rustc"


### PR DESCRIPTION
Notes:

- A submodule bump is made.
- A patch refresh is made.
- LLVM is updated to version 19.1.0.
- Rust is updated according to Chromium requirement.
- A patch is added to fix `re2` include issue.
- `fix-disabling-safebrowsing` patch is updated to fix a mojom dependency issue.

---

Builds and runs fine locally.

![CleanShot 2024-09-21 at 20 38 48](https://github.com/user-attachments/assets/8eec16fa-6be6-46c1-997b-6448592a8ba0)

---

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>