### PR TITLE
Update to ungoogled-chromium 131.0.6778.69

### DIFF
--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = 8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2024-09-04
+version = 2024-09-23
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2024-09-04
+version = 2024-09-23
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/macos/fix-dependency
+++ b/patches/macos/fix-dependency
@@ -1,0 +1,11 @@
+--- a/chrome/BUILD.gn
++++ b/chrome/BUILD.gn
+@@ -1212,8 +1212,6 @@ if (is_win) {
+       ":optimization_guide_library",
+       ":swiftshader_binaries",
+       ":widevine_cdm_library",
+-      "//chrome/browser/resources/media/mei_preload:component_bundle",
+-      "//components/privacy_sandbox/privacy_sandbox_attestations/preload:component_bundle",
+     ]
+ 
+     if (is_chrome_branded) {

--- a/patches/series
+++ b/patches/series
@@ -11,3 +11,4 @@ ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
 ungoogled-chromium/macos/mark-remap_alloc-used.patch
 ungoogled-chromium/macos/re2-include-fix
+macos/fix-dependency

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1625,8 +1625,7 @@ config("compiler_deterministic") {
+@@ -1628,8 +1628,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1275,7 +1275,7 @@ if (is_win) {
+@@ -1257,7 +1257,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -246,8 +246,6 @@ clang_lib("compiler_builtins") {
+@@ -220,8 +220,6 @@ clang_lib("compiler_builtins") {
      } else {
        libname = "ios"
      }

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -28,7 +28,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc 1.83.0-nightly (d6c8169c1 2024-09-03)"
++  rustc_version = "rustc 1.83.0-nightly (6c6d21008 2024-09-22)"
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1800,10 +1800,6 @@ static_library("browser") {
+@@ -1768,10 +1768,6 @@ static_library("browser") {
      "//chrome/browser/ui/omnibox:impl",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
@@ -13,8 +13,8 @@
      "//chrome/browser/ip_protection",
  
      # TODO(crbug.com/40110173): Eliminate usages of browser.h from Media Router.
-@@ -1932,7 +1928,6 @@ static_library("browser") {
-     "//chrome/browser/promos:utils",
+@@ -1924,7 +1920,6 @@ static_library("browser") {
+     "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
 -    "//chrome/browser/safe_browsing",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -700,9 +700,6 @@ source_set("extensions") {
+@@ -672,9 +672,6 @@ source_set("extensions") {
      # TODO(crbug.com/346472679): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
      # TODO(crbug.com/343037853): Remove this circular dependency.
      "//chrome/browser/themes",
  
-@@ -735,8 +732,6 @@ source_set("extensions") {
+@@ -711,8 +708,6 @@ source_set("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,17 +42,17 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -798,7 +793,6 @@ source_set("extensions") {
+@@ -783,7 +778,6 @@ source_set("extensions") {
      "//chrome/browser/profiles",
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:mojo_bindings",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/safe_browsing:metrics_collector",
+     "//chrome/browser/ui/safety_hub",
      "//chrome/browser/ui/tabs:tab_enums",
-     "//chrome/browser/web_applications",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -597,17 +597,8 @@ static_library("ui") {
+@@ -574,17 +574,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -70,7 +70,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -5994,7 +5985,6 @@ static_library("ui_public_dependencies")
+@@ -5694,7 +5685,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -171,7 +171,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7270,13 +7270,9 @@ test("unit_tests") {
+@@ -6825,13 +6825,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -200,7 +200,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2223,11 +2223,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2235,11 +2235,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -214,7 +214,7 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8041,18 +8041,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8054,28 +8054,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(compiler->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                   soda_language_pack_path.value()));
      return true;
@@ -230,6 +230,16 @@
 -    }
 -    return compiler->SetParameter(sandbox::policy::kParamScreenAiComponentPath,
 -                                  screen_ai_binary_path.value());
+-  } else if (sandbox_type == sandbox::mojom::Sandbox::kOnDeviceTranslation) {
+-    auto translatekit_binary_path =
+-        OnDeviceTranslationServiceController::GetTranslateKitComponentPath();
+-    if (translatekit_binary_path.empty()) {
+-      VLOG(1) << "TranslationKit component not found.";
+-      return false;
+-    }
+-    return compiler->SetParameter(
+-        sandbox::policy::kParamTranslatekitComponentPath,
+-        translatekit_binary_path.value());
    }
  
    return false;

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -67,7 +67,7 @@ while getopts 'dgp' OPTION; do
         _rustc_dir="$_rust_dir/rustc"
         _rustc_lib_dir="$_rust_dir/rustc/lib/rustlib/$_rust_name/lib"
 
-        echo "rustc 1.83.0-nightly (d6c8169c1 2024-09-03)" > "$_rust_flag_file"
+        echo "rustc 1.83.0-nightly (6c6d21008 2024-09-22)" > "$_rust_flag_file"
 
         mkdir -p "$_rust_bin_dir"
         mkdir -p "$_rust_dir/lib"


### PR DESCRIPTION
Notes:
- A submodule bump is made.
- A patch refresh is made.
- Rust is updated according to Chromium requirement.
- `mei-preload` and `privacy-sandbox` are disabled due to dependency issue (ref: https://github.com/ungoogled-software/ungoogled-chromium/pull/3089#issuecomment-2478899451)

---

Builds and runs fine locally.

![CleanShot 2024-11-15 at 10 09 35@2x](https://github.com/user-attachments/assets/6a741893-2576-41ba-9715-2acd5cbecb00)

---

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>