### PR TITLE
ci: Disable x86-64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
     name: Build macOS binaries of Ungoogled Chromium
     strategy:
       matrix:
-        arch: [arm64, x86-64]
+        # arch: [arm64, x86-64]
+        arch: [arm64]
         include:
           - arch: arm64
             os: macos-15


### PR DESCRIPTION
A small fix related to CI, which allows the build CI to properly run with x86_64 workflow disabled.