### PR TITLE
Update to ungoogled-chromium 132.0.6834.83

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,11 +41,6 @@ while getopts 'd' OPTION; do
   esac
 done
 
-# For packaging
-_chromium_version=$(cat "$_root_dir"/ungoogled-chromium/chromium_version.txt)
-_ungoogled_revision=$(cat "$_root_dir"/ungoogled-chromium/revision.txt)
-_package_revision=$(cat "$_root_dir"/revision.txt)
-
 # Add local clang and build tools to PATH
 # export PATH="$PATH:$_src_dir/third_party/llvm-build/Release+Asserts/bin"
 
@@ -90,6 +85,9 @@ fi
 /usr/bin/arch -$_arch $_python_path/python3 ./tools/rust/build_bindgen.py --rust-target $_rust_target
 
 /usr/bin/arch -$_arch ./out/Default/gn gen out/Default --fail-on-unused-args
+
+ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
+
 /usr/bin/arch -$_arch $_ninja_path/ninja -C out/Default chrome chromedriver
 
-./sign_and_package_app.sh
+/bin/zsh "$_root_dir/sign_and_package_app.sh"

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = 8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2024-09-23
+version = 2024-10-22
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2024-09-23
+version = 2024-10-22
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -10,5 +10,5 @@ is_clang=true
 is_debug=false
 is_official_build=true
 proprietary_codecs=true
-symbol_level=0
+symbol_level=1
 use_sysroot=false

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1628,8 +1628,7 @@ config("compiler_deterministic") {
+@@ -1648,8 +1648,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1255,7 +1255,7 @@ if (is_win) {
+@@ -1252,7 +1252,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -220,8 +220,6 @@ clang_lib("compiler_builtins") {
+@@ -223,8 +223,6 @@ clang_lib("compiler_builtins") {
      } else {
        libname = "ios"
      }
@@ -11,7 +11,7 @@
  
 --- a/build/config/rust.gni
 +++ b/build/config/rust.gni
-@@ -54,17 +54,17 @@ declare_args() {
+@@ -59,17 +59,17 @@ declare_args() {
    # To use a custom toolchain instead, specify an absolute path to the root of
    # a Rust sysroot, which will have a 'bin' directory and others. Commonly
    # <home dir>/.rustup/toolchains/nightly-<something>-<something>

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -28,7 +28,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc 1.83.0-nightly (6c6d21008 2024-09-22)"
++  rustc_version = "rustc 1.84.0-nightly (439284741 2024-10-21)"
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,8 +2,8 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1768,10 +1768,6 @@ static_library("browser") {
-     "//chrome/browser/ui/omnibox:impl",
+@@ -1741,10 +1741,6 @@ static_library("browser") {
+     "//chrome/browser/ui/javascript_dialogs:impl",
      "//chrome/browser/storage_access_api",
      "//chrome/browser/top_level_storage_access_api:permissions",
 -    "//chrome/browser/safe_browsing",
@@ -13,7 +13,7 @@
      "//chrome/browser/ip_protection",
  
      # TODO(crbug.com/40110173): Eliminate usages of browser.h from Media Router.
-@@ -1924,7 +1920,6 @@ static_library("browser") {
+@@ -1911,7 +1907,6 @@ static_library("browser") {
      "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -672,9 +672,6 @@ source_set("extensions") {
+@@ -660,9 +660,6 @@ source_set("extensions") {
      # TODO(crbug.com/346472679): Remove this circular dependency.
      "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
      # TODO(crbug.com/343037853): Remove this circular dependency.
      "//chrome/browser/themes",
  
-@@ -711,8 +708,6 @@ source_set("extensions") {
+@@ -700,8 +697,6 @@ source_set("extensions") {
      "//chrome/common",
      "//chrome/common/extensions/api",
      "//components/omnibox/browser",
@@ -42,7 +42,7 @@
      "//components/safe_browsing/core/common/proto:realtimeapi_proto",
      "//components/signin/core/browser",
      "//components/translate/content/browser",
-@@ -783,7 +778,6 @@ source_set("extensions") {
+@@ -776,7 +771,6 @@ source_set("extensions") {
      "//chrome/browser/profiles",
      "//chrome/browser/profiles:profile",
      "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -52,7 +52,7 @@
      "//chrome/browser/ui/tabs:tab_enums",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -574,17 +574,8 @@ static_library("ui") {
+@@ -567,17 +567,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -70,7 +70,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -5694,7 +5685,6 @@ static_library("ui_public_dependencies")
+@@ -5661,7 +5652,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -80,7 +80,7 @@
      "//components/sync_user_events",
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -416,8 +416,12 @@ void DownloadProtectionService::ShowDeta
+@@ -415,8 +415,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -95,7 +95,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -970,9 +970,13 @@ std::u16string DownloadItemNotification:
+@@ -961,9 +961,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -171,7 +171,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6825,13 +6825,9 @@ test("unit_tests") {
+@@ -6914,13 +6914,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -200,7 +200,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2235,11 +2235,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2254,12 +2254,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -209,15 +209,17 @@
 -    client_certificates::prefs::kProvisionManagedClientCertificateForUserPrefs,
 -    base::Value::Type::INTEGER },
 -#endif  // BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
+-
  #if !BUILDFLAG(IS_ANDROID)
    { key::kLensOverlaySettings,
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8054,28 +8054,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8055,30 +8055,6 @@ bool ChromeContentBrowserClient::SetupEm
+     CHECK(!soda_language_pack_path.empty());
      CHECK(compiler->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                   soda_language_pack_path.value()));
-     return true;
+-    return true;
 -  } else if (sandbox_type == sandbox::mojom::Sandbox::kScreenAI) {
 -    // ScreenAI service needs read access to ScreenAI component binary path to
 -    // load it.
@@ -232,7 +234,8 @@
 -                                  screen_ai_binary_path.value());
 -  } else if (sandbox_type == sandbox::mojom::Sandbox::kOnDeviceTranslation) {
 -    auto translatekit_binary_path =
--        OnDeviceTranslationServiceController::GetTranslateKitComponentPath();
+-        on_device_translation::ComponentManager::GetInstance()
+-            .GetTranslateKitComponentPath();
 -    if (translatekit_binary_path.empty()) {
 -      VLOG(1) << "TranslationKit component not found.";
 -      return false;

--- a/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
+++ b/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
@@ -1,6 +1,6 @@
 --- a/build/rust/std/remap_alloc.cc
 +++ b/build/rust/std/remap_alloc.cc
-@@ -74,7 +74,11 @@ extern "C" {
+@@ -92,7 +92,11 @@ extern "C" {
    __attribute__((visibility("default"))) __attribute__((weak))
  #endif
  #else
@@ -11,8 +11,8 @@
 +#endif
  #endif  // COMPONENT_BUILD
  
- // This must exist as the stdlib depends on it to prove that we know the
-@@ -84,8 +88,13 @@ extern "C" {
+ #if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC) && BUILDFLAG(IS_WIN) && \
+@@ -109,8 +113,13 @@ extern "C" {
  // Marked as weak as when Rust drives linking it includes this symbol itself,
  // and we don't want a collision due to C++ being in the same link target, where
  // C++ causes us to explicitly link in the stdlib and this symbol here.
@@ -25,4 +25,4 @@
 +#endif
  
  REMAP_ALLOC_ATTRIBUTES void* __rust_alloc(size_t size, size_t align) {
- #if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+ #if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -79,7 +79,7 @@ while getopts 'dgp' OPTION; do
         _rustc_dir="$_rust_dir/rustc"
         _rustc_lib_dir="$_rust_dir/rustc/lib/rustlib/$_rust_name/lib"
 
-        echo "rustc 1.83.0-nightly (6c6d21008 2024-09-22)" > "$_rust_flag_file"
+        echo "rustc 1.84.0-nightly (439284741 2024-10-21)" > "$_rust_flag_file"
 
         mkdir -p "$_rust_bin_dir"
         mkdir -p "$_rust_dir/lib"

--- a/sign_and_package_app.sh
+++ b/sign_and_package_app.sh
@@ -1,3 +1,10 @@
+_root_dir=$(dirname $(greadlink -f $0))
+
+# For packaging
+_chromium_version=$(cat "$_root_dir"/ungoogled-chromium/chromium_version.txt)
+_ungoogled_revision=$(cat "$_root_dir"/ungoogled-chromium/revision.txt)
+_package_revision=$(cat "$_root_dir"/revision.txt)
+
 # Fix issue where macOS requests permission for incoming network connections
 # See https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/17
 xattr -cs out/Default/Chromium.app


### PR DESCRIPTION
Notes:
- A submodule bump is made.
- A patch refresh is made.
- Rust is updated according to Chromium requirement.
- `symbol_level=1` flag is added to fix a linking issue (see https://github.com/ungoogled-software/ungoogled-chromium/pull/3143#issuecomment-2600861323).
- Fix local signing & packaging script.

---

Builds and runs fine locally.

<img width="697" alt="image" src="https://github.com/user-attachments/assets/ed6ff5b8-9faa-4c36-a187-69ef7ec4fdf3" />

---

Signed-off-by: Qian Qian "Cubik"‎ <cubik65536@cubik65536.top>