### PR TITLE
ci: Fix bindgen path issue

### DIFF
--- a/.github/scripts/github_build.sh
+++ b/.github/scripts/github_build.sh
@@ -16,6 +16,7 @@ _ninja_path="$_homebrew_path/ninja/bin"
 _python_path="$_homebrew_path/python3/bin"
 
 _root_dir=$(dirname $(greadlink -f $0))
+_src_dir="$_root_dir/build/src"
 if [[ -f "$_root_dir/epoch_job_start.txt" ]]; then
   epoch_job_start=$(cat "$_root_dir/epoch_job_start.txt")
   # GitHub's hard time limit is 6 h per job, we want to spare 1 h for steps before and after the build,
@@ -23,7 +24,9 @@ if [[ -f "$_root_dir/epoch_job_start.txt" ]]; then
   _remaining_time=$(( 360*60 - 60*60 - $(date +%s) + epoch_job_start ))
 fi
 
-cd build/src
+cd "$_src_dir"
+
+ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
 
 echo $(date +%s) | tee -a "$_root_dir/build_times_$_target_cpu.log"
 echo "status=running" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Sorry, forgot to fix this for GitHub Action environment in #219 :(

This is definitely not an ideal solution, but due to the time constraint I have now, I hope we can use this as a temporary walk-around (and hopefully get it fixed soon<sup>TM</sup> XD).

See: https://github.com/ungoogled-software/ungoogled-chromium/pull/3143#issuecomment-2601050952

---

P.S.: Chromium git service seems to be down (HTTP 503), so I will run the test later.