### PR TITLE
Cross compile x86-64 builds on arm64

### DIFF
--- a/.github/scripts/github_before_build.sh
+++ b/.github/scripts/github_before_build.sh
@@ -2,18 +2,7 @@
 
 # Simple script for getting ready to build Ungoogled-Chromium macOS binaries on GitHub Actions
 
-_target_cpu="$(/usr/bin/uname -m)"
-
-# Paths for required toolchain binaries
-_x86_64_homebrew_path="/usr/local/opt"
-_arm64_homebrew_path="/opt/homebrew/opt"
-_homebrew_path="$_x86_64_homebrew_path"
-if [[ $_target_cpu == "arm64" ]]; then
-  _homebrew_path="$_arm64_homebrew_path"
-fi
-_clangxx_path="$_homebrew_path/llvm/bin"
-_ninja_path="$_homebrew_path/ninja/bin"
-_python_path="$_homebrew_path/python3/bin"
+_target_cpu="$1"
 
 # Some path variables
 _root_dir=$(dirname $(greadlink -f $0))
@@ -34,12 +23,7 @@ cat "$_root_dir/flags.macos.gn" >> "$_src_dir/out/Default/args.gn"
 
 cd "$_src_dir"
 
-_rust_target="x86_64-apple-darwin"
-if [[ $_target_cpu == "arm64" ]]; then
-  _rust_target="aarch64-apple-darwin"
-fi
+./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
+./tools/rust/build_bindgen.py
 
-/usr/bin/arch -$_target_cpu $_python_path/python3 ./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
-/usr/bin/arch -$_target_cpu $_python_path/python3 ./tools/rust/build_bindgen.py --rust-target $_rust_target
-
-/usr/bin/arch -$_target_cpu ./out/Default/gn gen out/Default --fail-on-unused-args
+./out/Default/gn gen out/Default --fail-on-unused-args

--- a/.github/scripts/github_build.sh
+++ b/.github/scripts/github_build.sh
@@ -21,7 +21,20 @@ ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
 echo $(date +%s) | tee -a "$_root_dir/build_times_$_target_cpu.log"
 echo "status=running" >> $GITHUB_OUTPUT
 
+set +e
+
 timeout -k 7m -s SIGTERM ${_remaining_time:-19680}s ninja -C out/Default chrome chromedriver # 328 m as default $_remaining_time
+
+_error_code="${?}"
+if [[ "$_error_code" -eq 124 ]]; then
+    exit 0
+fi
+
+if [[ "$_error_code" -ne 0 ]]; then
+    exit "$_error_code"
+fi
+
+set -e
 
 echo $(date +%s) | tee "$_root_dir/build_finished_$_target_cpu.log"
 echo "status=finished" >> $GITHUB_OUTPUT

--- a/.github/scripts/github_build.sh
+++ b/.github/scripts/github_build.sh
@@ -5,16 +5,6 @@
 
 _target_cpu="${1:-x86_64}"
 
-_x86_64_homebrew_path="/usr/local/opt"
-_arm64_homebrew_path="/opt/homebrew/opt"
-_homebrew_path="$_x86_64_homebrew_path"
-if [[ $_target_cpu == "arm64" ]]; then
-  _homebrew_path="$_arm64_homebrew_path"
-fi
-_clangxx_path="$_homebrew_path/llvm/bin"
-_ninja_path="$_homebrew_path/ninja/bin"
-_python_path="$_homebrew_path/python3/bin"
-
 _root_dir=$(dirname $(greadlink -f $0))
 _src_dir="$_root_dir/build/src"
 if [[ -f "$_root_dir/epoch_job_start.txt" ]]; then
@@ -31,7 +21,7 @@ ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
 echo $(date +%s) | tee -a "$_root_dir/build_times_$_target_cpu.log"
 echo "status=running" >> $GITHUB_OUTPUT
 
-timeout --preserve-status -k 7m -s SIGTERM ${_remaining_time:-19680}s /usr/bin/arch -$_target_cpu $_ninja_path/ninja -C out/Default chrome chromedriver # 328 m as default $_remaining_time
+timeout -k 7m -s SIGTERM ${_remaining_time:-19680}s ninja -C out/Default chrome chromedriver # 328 m as default $_remaining_time
 
 echo $(date +%s) | tee "$_root_dir/build_finished_$_target_cpu.log"
 echo "status=finished" >> $GITHUB_OUTPUT

--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -2,16 +2,7 @@
 
 # Simple script for downloading and unpacking required resources to build Ungoogled-Chromium macOS binaries on GitHub Actions
 
-_target_cpu="$(/usr/bin/uname -m)"
-
-# Paths for required toolchain binaries
-_x86_64_homebrew_path="/usr/local/opt"
-_arm64_homebrew_path="/opt/homebrew/opt"
-_homebrew_path="$_x86_64_homebrew_path"
-if [[ $_target_cpu == "arm64" ]]; then
-  _homebrew_path="$_arm64_homebrew_path"
-fi
-_python_path="$_homebrew_path/python3/bin"
+_target_cpu="$1"
 
 _root_dir=$(dirname $(greadlink -f $0))
 _download_cache="$_root_dir/build/download_cache"
@@ -25,17 +16,17 @@ sudo du -hs "$_src_dir"
 rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
-/usr/bin/arch -$_target_cpu /bin/bash "$_root_dir/retrieve_and_unpack_resource.sh" -g
+"$_root_dir/retrieve_and_unpack_resource.sh" -g "$_target_cpu"
 
 mkdir -p "$_src_dir/out/Default"
 
-/usr/bin/arch -$_target_cpu $_python_path/python3 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
-/usr/bin/arch -$_target_cpu $_python_path/python3 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
-/usr/bin/arch -$_target_cpu $_python_path/python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
+python3 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
+python3 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
+python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
 
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-/usr/bin/arch -$_target_cpu /bin/bash "$_root_dir/retrieve_and_unpack_resource.sh" -p
+"$_root_dir/retrieve_and_unpack_resource.sh" -p "$_target_cpu"
 
 rm -rvf "$_download_cache"

--- a/.github/scripts/github_setup_env_toolchain.sh
+++ b/.github/scripts/github_setup_env_toolchain.sh
@@ -1,50 +1,8 @@
 #!/bin/bash -eux
 
-# Simple script for setting up all toolchain dependencies and environment variables for building Ungoogled-Chromium on macOS
+# Simple script for setting up all toolchain dependencies for building Ungoogled-Chromium on macOS
 
-_arch="$(/usr/bin/uname -m)"
-
-# Install Homebrew for x86_64 (arm64 installation is not needed as it comes pre-installed on GitHub Action Runners)
-if [[ $_arch == "x86_64" ]]; then
-  /usr/bin/arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
-
-# Install dependencies from Homebrew
-if [[ $_arch == "x86_64" ]]; then
-  # Install expat as a workaround for a bug in the Python 3.13 formula.
-  # See https://github.com/Homebrew/homebrew-core/issues/206778.
-  /usr/bin/arch -x86_64 /usr/local/bin/brew install expat
-  /usr/bin/arch -x86_64 /usr/local/bin/brew install python3 llvm ninja coreutils readline xz zlib binutils node --overwrite
-else
-  /usr/bin/arch -arm64 /opt/homebrew/bin/brew install python3 llvm ninja coreutils readline xz zlib binutils node --overwrite
-fi
-
-# Paths for required toolchain binaries
-_x86_64_homebrew_path="/usr/local/opt"
-_arm64_homebrew_path="/opt/homebrew/opt"
-_homebrew_path="$_x86_64_homebrew_path"
-if [[ $_arch == "arm64" ]]; then
-  _homebrew_path="$_arm64_homebrew_path"
-fi
-_clangxx_path="$_homebrew_path/llvm/bin"
-_ninja_path="$_homebrew_path/ninja/bin"
-_python_path="$_homebrew_path/python3/bin"
+brew install ninja coreutils --overwrite
 
 # Install httplib2 for Python from PyPI
-/usr/bin/arch -$_arch $_python_path/pip3 install httplib2 --break-system-packages
-
-# Set environment variables
-export PATH="$_clangxx_path:$_ninja_path:$_python_path:$PATH"
-export CXX="$_clangxx_path/clang++"
-export NINJA="$_ninja_path/ninja"
-export LDFLAGS="-L$_homebrew_path/llvm/lib"
-export CPPFLAGS="-I$_homebrew_path/llvm/include"
-
-# Setup GitHub Actions environment variables
-echo "$_clangxx_path" >> $GITHUB_PATH
-echo "$_ninja_path" >> $GITHUB_PATH
-echo "$_python_path" >> $GITHUB_PATH
-echo "CXX=$_clangxx_path/clang++" >> $GITHUB_ENV
-echo "NINJA=$_ninja_path/ninja" >> $GITHUB_ENV
-echo "LDFLAGS=-L$_homebrew_path/llvm/lib" >> $GITHUB_ENV
-echo "CPPFLAGS=-I$_homebrew_path/llvm/include" >> $GITHUB_ENV
+pip3 install httplib2 --break-system-packages

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -44,14 +44,10 @@ jobs:
         run: cp -va ./.github/scripts/ ./
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Download and unpack required resources
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_fetch_resources.sh | tee -a github_actions_retrieve_resources.log
+        run: ./github_fetch_resources.sh ${{ inputs.arch }} | tee -a github_actions_retrieve_resources.log
       - name: List resources
         run: ls -la
       - name: Archive resources
@@ -87,12 +83,8 @@ jobs:
         run: sudo mdutil -a -i off
       - name: Run xcode-select
         run: sudo xcode-select --switch /Applications/Xcode_16.app
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Download resources
         uses: actions/download-artifact@v4
         with:
@@ -102,10 +94,9 @@ jobs:
       - name: List resources
         run: ls -la
       - name: Prepare for building
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_before_build.sh | tee -a github_actions_build_${{ inputs.arch }}.log
+        run: ./github_before_build.sh ${{ inputs.arch }} | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -165,17 +156,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -235,17 +221,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -305,17 +286,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -375,17 +351,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -445,17 +416,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -515,17 +481,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -585,17 +546,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake
@@ -655,17 +611,12 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: github_build_artifact_${{ inputs.arch }}
-      - name: Install Rosetta 2
-        # Only install Rosetta 2 when building for x86_64
-        if: ${{ inputs.arch == 'x86_64' }}
-        run: softwareupdate --install-rosetta --agree-to-license
       - name: Setup Environment and Toolchain
-        run: /usr/bin/arch -${{ inputs.arch }} /bin/bash ./github_setup_env_toolchain.sh | tee -a github_actions_setup_env_toolchain.log
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Unpack archive of build
         run: ./github_unpack_archive.sh
       - name: Resume Build
         id: build
-        continue-on-error: true
         run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
       - name: Prepare archive of build as artifact
         id: bake

--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Finally, run the following (if you are building for the same architecture as you
 ./build.sh
 ```
 
-or, if you want to build for x86_64 on an Apple Silicon Mac (and if you have Rosetta 2 and other necessary tools for x86_64 installed):
+or, if you want to build for x86_64 on an Apple Silicon Mac:
 
 ```sh
-/usr/bin/arch -x86_64 /bin/zsh ./build.sh
+./build.sh x86_64
 ```
 
 Once it's complete, a `.dmg` should appear in `build/`.

--- a/build.sh
+++ b/build.sh
@@ -4,27 +4,6 @@ set -eux
 
 # Build script for local macOS environment
 
-# The architecture of the running shell
-# Also used to determine the build target architecture
-_arch="$(/usr/bin/uname -m)"
-
-# Paths for required toolchain binaries
-_x86_64_homebrew_path="/usr/local/opt"
-_arm64_homebrew_path="/opt/homebrew/opt"
-_homebrew_path="$_x86_64_homebrew_path"
-if [[ $_arch == "arm64" ]]; then
-  _homebrew_path="$_arm64_homebrew_path"
-fi
-_clangxx_path="$_homebrew_path/llvm/bin"
-_ninja_path="$_homebrew_path/ninja/bin"
-_python_path="$_homebrew_path/python3/bin"
-
-export PATH="$_clangxx_path:$_ninja_path:$_python_path:$PATH"
-export CXX="$_clangxx_path/clang++"
-export NINJA="$_ninja_path/ninja"
-export LDFLAGS="-L$_homebrew_path/llvm/lib"
-export CPPFLAGS="-I$_homebrew_path/llvm/include"
-
 # Some path variables
 _root_dir=$(dirname $(greadlink -f $0))
 _download_cache="$_root_dir/build/download_cache"
@@ -41,6 +20,10 @@ while getopts 'd' OPTION; do
   esac
 done
 
+shift "$(($OPTIND -1))"
+
+_arch=${1:-arm64}
+
 # Add local clang and build tools to PATH
 # export PATH="$PATH:$_src_dir/third_party/llvm-build/Release+Asserts/bin"
 
@@ -48,17 +31,17 @@ rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
 if $clone; then
-  /usr/bin/arch -$_arch /bin/zsh "$_root_dir/retrieve_and_unpack_resource.sh" -g
+  "$_root_dir/retrieve_and_unpack_resource.sh" -g $_arch
 else
-  /usr/bin/arch -$_arch /bin/zsh "$_root_dir/retrieve_and_unpack_resource.sh" -d -g
+  "$_root_dir/retrieve_and_unpack_resource.sh" -d -g $_arch
 fi
 
 mkdir -p "$_src_dir/out/Default"
 
 # Apply patches and substitutions
-/usr/bin/arch -$_arch $_python_path/python3 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
-/usr/bin/arch -$_arch $_python_path/python3 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
-/usr/bin/arch -$_arch $_python_path/python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
+python3 "$_main_repo/utils/prune_binaries.py" "$_src_dir" "$_main_repo/pruning.list"
+python3 "$_main_repo/utils/patches.py" apply "$_src_dir" "$_main_repo/patches" "$_root_dir/patches"
+python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_regex.list" -f "$_main_repo/domain_substitution.list" "$_src_dir"
 # Set build flags
 cat "$_main_repo/flags.gn" "$_root_dir/flags.macos.gn" > "$_src_dir/out/Default/args.gn"
 
@@ -72,22 +55,17 @@ fi
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-/usr/bin/arch -$_arch /bin/zsh "$_root_dir/retrieve_and_unpack_resource.sh" -p
+"$_root_dir/retrieve_and_unpack_resource.sh" -p $_arch
 
 cd "$_src_dir"
 
-_rust_target="x86_64-apple-darwin"
-if [[ $_arch == "arm64" ]]; then
-  _rust_target="aarch64-apple-darwin"
-fi
+./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
+./tools/rust/build_bindgen.py
 
-/usr/bin/arch -$_arch $_python_path/python3 ./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
-/usr/bin/arch -$_arch $_python_path/python3 ./tools/rust/build_bindgen.py --rust-target $_rust_target
-
-/usr/bin/arch -$_arch ./out/Default/gn gen out/Default --fail-on-unused-args
+./out/Default/gn gen out/Default --fail-on-unused-args
 
 ln -s "$_src_dir/third_party" "$_src_dir/../third_party"
 
-/usr/bin/arch -$_arch $_ninja_path/ninja -C out/Default chrome chromedriver
+ninja -C out/Default chrome chromedriver
 
-/bin/zsh "$_root_dir/sign_and_package_app.sh"
+"$_root_dir/sign_and_package_app.sh"

--- a/downloads-arm64-rustlib.ini
+++ b/downloads-arm64-rustlib.ini
@@ -1,0 +1,6 @@
+[rustlib-arm64]
+version = 2024-12-20
+url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
+download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
+output_path = third_party/rust-toolchain/rustc/lib/rustlib
+strip_leading_dirs = rust-nightly-aarch64-apple-darwin/rust-std-aarch64-apple-darwin/lib/rustlib

--- a/downloads-x86-64-rustlib.ini
+++ b/downloads-x86-64-rustlib.ini
@@ -1,0 +1,6 @@
+[rustlib-x86-64]
+version = 2024-12-20
+url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
+download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
+output_path = third_party/rust-toolchain/rustc/lib/rustlib
+strip_leading_dirs = rust-nightly-x86_64-apple-darwin/rust-std-x86_64-apple-darwin/lib/rustlib


### PR DESCRIPTION
So I needed a proper browser for a secondary x86-64 mac (since Firefox just stopped being an option and I couldn't compile WebKit for that machine due to resource constraints), so I figured I'd do a quick build of UGC. Unfortunately, the build ended up not being so quick after all, so I spent some time improving the setup.

Essentially, this removes Rosetta 2 from the build process, and instead creates a full cross compilation setup. The main obstacle to that was that you need the target's standard rust libraries installed in the correct location, but that's now handled by the `downloads-arm64-rustlib.ini` and `downloads-x86-64-rustlib.ini` files, which try to find the respective `*-apple-darwin` directory inside the toolchain, and place that in `third_party/rust-toolchain/rustc/lib/rustlib`.

Compared to the Rosetta 2 approach, this makes the build process complete ~10 hours earlier, which is roughly a 1.4X speedup (these numbers are from this [test run](https://github.com/implicitfield/ungoogled-chromium-macos/actions/runs/13624711373), which is fairly close to the state of this PR.)

There's also some other random cleanup thrown in, mainly to make some of the build scripts slightly more robust. I believe this shouldn't impact maintainability much; the main thing to keep in mind is that you'll need to update the rust version in `downloads-arm64-rustlib.ini` and `downloads-x86-64-rustlib.ini` when rolling the rust toolchain.

Also, thanks to @Cubik65536 for maintaining this repository, I can see a lot of work has been put into the packaging here!