### PR TITLE
Update to ungoogled-chromium 134.0.6998.35

### DIFF
--- a/downloads-arm64-rustlib.ini
+++ b/downloads-arm64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-arm64]
-version = 2024-12-20
+version = 2025-02-15
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = 8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2024-12-20
+version = 2025-02-15
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64-rustlib.ini
+++ b/downloads-x86-64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-x86-64]
-version = 2024-12-20
+version = 2025-02-15
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2024-12-20
+version = 2025-02-15
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1647,8 +1647,7 @@ config("compiler_deterministic") {
+@@ -1641,8 +1641,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -12,10 +12,10 @@
        "--verify-version=$clang_version",
 --- a/build/toolchain/toolchain.gni
 +++ b/build/toolchain/toolchain.gni
-@@ -51,7 +51,7 @@ declare_args() {
-   if (llvm_android_mainline) {  # https://crbug.com/1481060
-     clang_version = "17"
+@@ -54,7 +54,7 @@ declare_args() {
+     clang_version = "21"
    } else {
+     # TODO(crbug.com/392929930): Remove in the next Clang roll.
 -    clang_version = "20"
 +    clang_version = "19"
    }

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1255,7 +1255,7 @@ if (is_win) {
+@@ -1241,7 +1241,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -28,7 +28,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc 1.85.0-nightly (9e136a30a 2024-12-19)"
++  rustc_version = "rustc 1.86.0-nightly (69fd5e405 2025-02-15)"
  
    # If you're using a Rust toolchain as specified by rust_sysroot_absolute,
    # you can specify whether it supports nacl here.

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,18 +2,18 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1724,10 +1724,6 @@ static_library("browser") {
-     "//chrome/browser/ui/javascript_dialogs:impl",
-     "//chrome/browser/storage_access_api",
-     "//chrome/browser/top_level_storage_access_api:permissions",
+@@ -1742,10 +1742,6 @@ static_library("browser") {
+     "//chrome/browser/prefs:util_impl",
+     "//chrome/browser/profiles:profiles_extra_parts_impl",
+     "//chrome/browser/profiles:profile_util_impl",
 -    "//chrome/browser/safe_browsing",
--    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 -    "//chrome/browser/safe_browsing:advanced_protection",
 -    "//chrome/browser/safe_browsing:metrics_collector",
-     "//chrome/browser/ip_protection",
- 
-     # TODO(crbug.com/40110173): Eliminate usages of browser.h from Media Router.
-@@ -1887,7 +1883,6 @@ static_library("browser") {
+-    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
+     "//chrome/browser/search",
+     "//chrome/browser/search_engine_choice:impl",
+     "//chrome/browser/signin:impl",
+@@ -1921,7 +1917,6 @@ static_library("browser") {
      "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -670,9 +670,6 @@ source_set("extensions") {
+@@ -666,9 +666,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -710,8 +707,6 @@ source_set("extensions") {
+@@ -706,8 +703,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -42,7 +42,7 @@
        "//components/safe_browsing/core/common/proto:realtimeapi_proto",
        "//components/signin/core/browser",
        "//components/translate/content/browser",
-@@ -785,7 +780,6 @@ source_set("extensions") {
+@@ -782,7 +777,6 @@ source_set("extensions") {
        "//chrome/browser/profiles",
        "//chrome/browser/profiles:profile",
        "//chrome/browser/resource_coordinator:mojo_bindings",
@@ -52,7 +52,7 @@
        "//chrome/browser/ui/tabs:tab_enums",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -575,17 +575,8 @@ static_library("ui") {
+@@ -570,17 +570,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -70,7 +70,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -5634,7 +5625,6 @@ static_library("ui_public_dependencies")
+@@ -5674,7 +5665,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -111,7 +111,7 @@
                ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
 --- a/chrome/browser/ui/webui/downloads/downloads_ui.cc
 +++ b/chrome/browser/ui/webui/downloads/downloads_ui.cc
-@@ -40,6 +40,7 @@
+@@ -39,6 +39,7 @@
  #include "components/history/core/common/pref_names.h"
  #include "components/prefs/pref_service.h"
  #include "components/profile_metrics/browser_profile_type.h"
@@ -119,7 +119,7 @@
  #include "components/safe_browsing/core/common/features.h"
  #include "components/strings/grit/components_strings.h"
  #include "content/public/browser/download_manager.h"
-@@ -69,10 +70,12 @@ content::WebUIDataSource* CreateAndAddDo
+@@ -68,10 +69,12 @@ content::WebUIDataSource* CreateAndAddDo
    webui::SetupWebUIDataSource(source, kDownloadsResources,
                                IDR_DOWNLOADS_DOWNLOADS_HTML);
  
@@ -155,7 +155,7 @@
        return l10n_util::GetStringFUTF16(IDS_PROMPT_DOWNLOAD_CHANGES_SETTINGS,
 --- a/chrome/browser/ui/views/download/download_item_view.cc
 +++ b/chrome/browser/ui/views/download/download_item_view.cc
-@@ -1034,11 +1034,13 @@ ui::ImageModel DownloadItemView::GetIcon
+@@ -1041,11 +1041,13 @@ ui::ImageModel DownloadItemView::GetIcon
  
    switch (danger_type) {
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
@@ -171,7 +171,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7012,13 +7012,9 @@ test("unit_tests") {
+@@ -7099,13 +7099,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -200,13 +200,16 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2264,12 +2264,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2286,15 +2286,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
 -#if BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
 -  { key::kProvisionManagedClientCertificateForUser,
 -    client_certificates::prefs::kProvisionManagedClientCertificateForUserPrefs,
+-    base::Value::Type::INTEGER },
+-  { key::kProvisionManagedClientCertificateForBrowser,
+-    client_certificates::prefs::kProvisionManagedClientCertificateForBrowserPrefs,
 -    base::Value::Type::INTEGER },
 -#endif  // BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
 -
@@ -215,12 +218,13 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7871,30 +7871,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -7889,33 +7889,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
-     CHECK(compiler->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
-                                  soda_language_pack_path.value()));
+     CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
+                                    soda_language_pack_path.value()));
 -    return true;
--  } else if (sandbox_type == sandbox::mojom::Sandbox::kScreenAI) {
+-  }
+-  if (sandbox_type == sandbox::mojom::Sandbox::kScreenAI) {
 -    // ScreenAI service needs read access to ScreenAI component binary path to
 -    // load it.
 -    base::FilePath screen_ai_binary_path =
@@ -230,9 +234,11 @@
 -      VLOG(1) << "Screen AI component not found.";
 -      return false;
 -    }
--    return compiler->SetParameter(sandbox::policy::kParamScreenAiComponentPath,
--                                  screen_ai_binary_path.value());
--  } else if (sandbox_type == sandbox::mojom::Sandbox::kOnDeviceTranslation) {
+-    return serializer->SetParameter(
+-        sandbox::policy::kParamScreenAiComponentPath,
+-        screen_ai_binary_path.value());
+-  }
+-  if (sandbox_type == sandbox::mojom::Sandbox::kOnDeviceTranslation) {
 -    auto translatekit_binary_path =
 -        on_device_translation::ComponentManager::GetInstance()
 -            .GetTranslateKitComponentPath();
@@ -240,7 +246,7 @@
 -      VLOG(1) << "TranslationKit component not found.";
 -      return false;
 -    }
--    return compiler->SetParameter(
+-    return serializer->SetParameter(
 -        sandbox::policy::kParamTranslatekitComponentPath,
 -        translatekit_binary_path.value());
    }

--- a/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
+++ b/patches/ungoogled-chromium/macos/mark-remap_alloc-used.patch
@@ -1,6 +1,6 @@
 --- a/build/rust/std/remap_alloc.cc
 +++ b/build/rust/std/remap_alloc.cc
-@@ -92,7 +92,11 @@ extern "C" {
+@@ -97,7 +97,11 @@ extern "C" {
    __attribute__((visibility("default"))) __attribute__((weak))
  #endif
  #else
@@ -12,7 +12,7 @@
  #endif  // COMPONENT_BUILD
  
  #if !BUILDFLAG(RUST_ALLOCATOR_USES_PARTITION_ALLOC) && BUILDFLAG(IS_WIN) && \
-@@ -109,8 +113,13 @@ extern "C" {
+@@ -114,8 +118,13 @@ extern "C" {
  // Marked as weak as when Rust drives linking it includes this symbol itself,
  // and we don't want a collision due to C++ being in the same link target, where
  // C++ causes us to explicitly link in the stdlib and this symbol here.

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -98,7 +98,7 @@ if $retrieve_arch_specific; then
     _rustc_dir="$_rust_dir/rustc"
     _rustc_lib_dir="$_rust_dir/rustc/lib/rustlib/$_rust_name/lib"
 
-    echo "rustc 1.85.0-nightly (9e136a30a 2024-12-19)" > "$_rust_flag_file"
+    echo "rustc 1.85.0-nightly (69fd5e405 2025-02-15)" > "$_rust_flag_file"
 
     mkdir -p "$_rust_bin_dir"
     mkdir -p "$_rust_dir/lib"


### PR DESCRIPTION
https://github.com/ungoogled-software/ungoogled-chromium/issues/3229

~~Still need to bump the rust version to fix a build failure, will undraft when I get it to fully build.~~ Builds fine!

Bumping rust due to this build error (based on an investigation from https://bugs.gentoo.org/950040):
```
[355/51474] COPY clang_arm64_for_rust_host_build_tools/obj/build/rust/std/libadler2.rlib clang_arm64_for_rust_host_build_tools/prebuilt_rustc_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libadler2.rlib
FAILED: clang_arm64_for_rust_host_build_tools/prebuilt_rustc_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libadler2.rlib
ln -f clang_arm64_for_rust_host_build_tools/obj/build/rust/std/libadler2.rlib clang_arm64_for_rust_host_build_tools/prebuilt_rustc_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libadler2.rlib 2>/dev/null || (rm -rf clang_arm64_for_rust_host_build_tools/prebuilt_rustc_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libadler2.rlib && cp -af clang_arm64_for_rust_host_build_tools/obj/build/rust/std/libadler2.rlib clang_arm64_for_rust_host_build_tools/prebuilt_rustc_sysroot/lib/rustlib/aarch64-apple-darwin/lib/libadler2.rlib)
cp: clang_arm64_for_rust_host_build_tools/obj/build/rust/std/libadler2.rlib: No such file or directory
```
