### PR TITLE
Update to ungoogled-chromium 135.0.7049.52

### DIFF
--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -10,11 +10,11 @@ sha512 = 14df960c45cc9728a40abf46b4483dc5cbd1a95cd771ab3f7b61b0d0e252833ab1b1d06
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]
-version = 16.13.0
+version = 22.14.0
 url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-arm64.tar.xz
 download_filename = node-v%(version)s-darwin-arm64.tar.xz
 strip_leading_dirs = node-v%(version)s-darwin-arm64
-sha512 = 8678a2baf8d0c1c0e74ccf64c0dfdbb634e4c99d5770f20cf670f0a725885c668d7950e31cb1cbb08df78c6ef030a2dff8b9574e8817c74acbcb58a109b5ad9e
+sha512 = 2216e400fd722ab26bcfd0cbe2651f75be70597021e2efd0ac1f8b0c3e9f2ff4d16e9653520fc9d0150bdf0d7cebc4d5c9910c46cd52a7aef6c5f6824092fe95
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -10,11 +10,11 @@ sha512 = c177ea4d2265d8d03452d88705a12c1c02c05373399a821c50cd4118a60224bcd042935
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]
-version = 16.13.0
+version = 22.14.0
 url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
 download_filename = node-v%(version)s-darwin-x64.tar.xz
 strip_leading_dirs = node-v%(version)s-darwin-x64
-sha512 = 0e2ad3e108a6a2e938180ac958094476d5217e77176ecd18f6eb7f295ac2890781577c6dd243a9ce8633f319fed8e628738094cdd0ff036f4f5cfdf93d46fdc0
+sha512 = c0060b164ee77bd9df4e0efccb24d99e59899cbe3072812fb2024e64622db69bab7da0d9fb860c53c275a98593b4f96eddcc0d4371e3efc0e96851727eafd0a9
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1641,8 +1641,7 @@ config("compiler_deterministic") {
+@@ -1630,8 +1630,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -12,11 +12,11 @@
        "--verify-version=$clang_version",
 --- a/build/toolchain/toolchain.gni
 +++ b/build/toolchain/toolchain.gni
-@@ -54,7 +54,7 @@ declare_args() {
-     clang_version = "21"
+@@ -51,7 +51,7 @@ declare_args() {
+   if (llvm_android_mainline) {  # https://crbug.com/1481060
+     clang_version = "17"
    } else {
-     # TODO(crbug.com/392929930): Remove in the next Clang roll.
--    clang_version = "20"
+-    clang_version = "21"
 +    clang_version = "19"
    }
  }

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1742,10 +1742,6 @@ static_library("browser") {
+@@ -1757,10 +1757,6 @@ static_library("browser") {
      "//chrome/browser/prefs:util_impl",
      "//chrome/browser/profiles:profiles_extra_parts_impl",
      "//chrome/browser/profiles:profile_util_impl",
@@ -13,7 +13,7 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -1921,7 +1917,6 @@ static_library("browser") {
+@@ -1938,7 +1934,6 @@ static_library("browser") {
      "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -666,9 +666,6 @@ source_set("extensions") {
+@@ -745,9 +745,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,26 +33,17 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -706,8 +703,6 @@ source_set("extensions") {
+@@ -785,7 +782,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
--      "//components/safe_browsing/core/browser/db:util",
 -      "//components/safe_browsing/core/common/proto:csd_proto",
        "//components/safe_browsing/core/common/proto:realtimeapi_proto",
        "//components/signin/core/browser",
        "//components/translate/content/browser",
-@@ -782,7 +777,6 @@ source_set("extensions") {
-       "//chrome/browser/profiles",
-       "//chrome/browser/profiles:profile",
-       "//chrome/browser/resource_coordinator:mojo_bindings",
--      "//chrome/browser/safe_browsing",
-       "//chrome/browser/safe_browsing:metrics_collector",
-       "//chrome/browser/ui/safety_hub",
-       "//chrome/browser/ui/tabs:tab_enums",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -570,17 +570,8 @@ static_library("ui") {
+@@ -573,17 +573,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -70,7 +61,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -5674,7 +5665,6 @@ static_library("ui_public_dependencies")
+@@ -5681,7 +5672,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -80,7 +71,7 @@
      "//components/sync_user_events",
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -415,8 +415,12 @@ void DownloadProtectionService::ShowDeta
+@@ -429,8 +429,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -95,7 +86,7 @@
      learn_more_url = GURL(chrome::kAdvancedProtectionDownloadLearnMoreURL);
 --- a/chrome/browser/download/notification/download_item_notification.cc
 +++ b/chrome/browser/download/notification/download_item_notification.cc
-@@ -961,9 +961,13 @@ std::u16string DownloadItemNotification:
+@@ -956,9 +956,13 @@ std::u16string DownloadItemNotification:
      }
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT: {
        bool requests_ap_verdicts =
@@ -155,7 +146,7 @@
        return l10n_util::GetStringFUTF16(IDS_PROMPT_DOWNLOAD_CHANGES_SETTINGS,
 --- a/chrome/browser/ui/views/download/download_item_view.cc
 +++ b/chrome/browser/ui/views/download/download_item_view.cc
-@@ -1041,11 +1041,13 @@ ui::ImageModel DownloadItemView::GetIcon
+@@ -1051,11 +1051,13 @@ ui::ImageModel DownloadItemView::GetIcon
  
    switch (danger_type) {
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
@@ -171,7 +162,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7099,13 +7099,9 @@ test("unit_tests") {
+@@ -7116,13 +7116,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -200,7 +191,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2286,15 +2286,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2284,15 +2284,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -218,7 +209,7 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7889,33 +7889,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -7985,33 +7985,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
+++ b/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
@@ -1,6 +1,6 @@
 --- a/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
 +++ b/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
-@@ -54,7 +54,7 @@ logging.basicConfig(
+@@ -56,7 +56,7 @@ logging.basicConfig(
  
  def runTsc(tsconfig_location):
      cmd = [NODE_LOCATION, TSC_LOCATION, '-p', tsconfig_location]
@@ -9,16 +9,3 @@
      process = subprocess.Popen(cmd,
                                 stdout=subprocess.PIPE,
                                 stderr=subprocess.PIPE,
-@@ -105,9 +105,9 @@ def runTscRemote(tsconfig_location, all_
-                      rewrapper_exec_root), '--', relative_node_location,
-         relative_tsc_location, '-p', relative_tsconfig_location
-     ],
--                               stdout=subprocess.PIPE,
--                               stderr=subprocess.PIPE,
--                               universal_newlines=True)
-+        stdout=subprocess.PIPE,
-+        stderr=subprocess.PIPE,
-+        universal_newlines=True)
-     stdout, stderr = process.communicate()
-     # TypeScript does not correctly write to stderr because of https://github.com/microsoft/TypeScript/issues/33849
-     return process.returncode, stdout + stderr


### PR DESCRIPTION
Depends on ungoogled-software/ungoogled-chromium#3259

<img width="390" alt="Screenshot 2025-03-28 at 10 08 13" src="https://github.com/user-attachments/assets/a3855d81-082c-4945-89fa-bee30d357ab4" />

Bumped node.js version to latest LTS due to `import.meta.dirname` being undefined:
```
Oops! Something went wrong! :(

ESLint: 9.20.1

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:371:5)
    at validateString (node:internal/validators:119:11)
    at Object.join (node:path:1172:7)
    at file://<snip>/build/src/out/Default/gen/ui/webui/resources/cr_components/history/eslint.config.mjs?mtime=1743111682356:10:26
```