### PR TITLE
Update to ungoogled-chromium 136.0.7103.59

### DIFF
--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -10,11 +10,11 @@ sha512 = 14df960c45cc9728a40abf46b4483dc5cbd1a95cd771ab3f7b61b0d0e252833ab1b1d06
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]
-version = 22.14.0
+version = 22.11.0
 url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-arm64.tar.xz
 download_filename = node-v%(version)s-darwin-arm64.tar.xz
 strip_leading_dirs = node-v%(version)s-darwin-arm64
-sha512 = 2216e400fd722ab26bcfd0cbe2651f75be70597021e2efd0ac1f8b0c3e9f2ff4d16e9653520fc9d0150bdf0d7cebc4d5c9910c46cd52a7aef6c5f6824092fe95
+sha512 = 1ba7ec05c1445c03d561cc9acc50d64446bf71ae54c657fecb2ee1cfaa3739906ee8e018d40affc0f8165a124f9181214ba19455a18495619afef0d659a8c53a
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -10,11 +10,11 @@ sha512 = c177ea4d2265d8d03452d88705a12c1c02c05373399a821c50cd4118a60224bcd042935
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]
-version = 22.14.0
+version = 22.11.0
 url = https://nodejs.org/dist/v%(version)s/node-v%(version)s-darwin-x64.tar.xz
 download_filename = node-v%(version)s-darwin-x64.tar.xz
 strip_leading_dirs = node-v%(version)s-darwin-x64
-sha512 = c0060b164ee77bd9df4e0efccb24d99e59899cbe3072812fb2024e64622db69bab7da0d9fb860c53c275a98593b4f96eddcc0d4371e3efc0e96851727eafd0a9
+sha512 = 0fdd6978268f8f7f6d3dd2a4f965eb7dbf0a4e0d5560fa7f6da58a65b7b75ab51ac209ba17779ffb8506cc5d64887ae03b68fea68d78e796cd25ceac583c24c6
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]

--- a/patches/series
+++ b/patches/series
@@ -1,5 +1,6 @@
 ungoogled-chromium/macos/build-bindgen.patch
 ungoogled-chromium/macos/disable-clang-version-check.patch
+ungoogled-chromium/macos/disable-warning-suppression.patch
 ungoogled-chromium/macos/disable-crashpad-handler.patch
 ungoogled-chromium/macos/disable-symbol-order-verification.patch
 ungoogled-chromium/macos/fix-build-with-rust.patch

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1630,8 +1630,7 @@ config("compiler_deterministic") {
+@@ -1619,8 +1619,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1241,7 +1241,7 @@ if (is_win) {
+@@ -1245,7 +1245,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/disable-warning-suppression.patch
+++ b/patches/ungoogled-chromium/macos/disable-warning-suppression.patch
@@ -1,0 +1,10 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -312,7 +312,6 @@ config("compiler") {
+     ":compiler_cpu_abi",
+     ":compiler_codegen",
+     ":compiler_deterministic",
+-    ":clang_warning_suppression",
+   ]
+ 
+   # Here we enable -fno-delete-null-pointer-checks, which makes various nullptr

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,8 +1,8 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -261,8 +261,6 @@ clang_lib("compiler_builtins") {
+@@ -276,8 +276,6 @@ clang_lib("compiler_builtins") {
      } else {
-       libname = "ios"
+       assert(false, "unsupported target_platform=$target_platform")
      }
 -  } else {
 -    libname = "builtins"
@@ -11,7 +11,7 @@
  
 --- a/build/config/rust.gni
 +++ b/build/config/rust.gni
-@@ -58,17 +58,17 @@ declare_args() {
+@@ -59,17 +59,17 @@ declare_args() {
    # To use a custom toolchain instead, specify an absolute path to the root of
    # a Rust sysroot, which will have a 'bin' directory and others. Commonly
    # <home dir>/.rustup/toolchains/nightly-<something>-<something>

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1757,10 +1757,6 @@ static_library("browser") {
+@@ -1783,10 +1783,6 @@ static_library("browser") {
      "//chrome/browser/prefs:util_impl",
      "//chrome/browser/profiles:profiles_extra_parts_impl",
      "//chrome/browser/profiles:profile_util_impl",
@@ -13,7 +13,7 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -1938,7 +1934,6 @@ static_library("browser") {
+@@ -1964,7 +1960,6 @@ static_library("browser") {
      "//chrome/browser/reading_list",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -745,9 +745,6 @@ source_set("extensions") {
+@@ -773,9 +773,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -785,7 +782,6 @@ source_set("extensions") {
+@@ -812,7 +809,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -43,7 +43,7 @@
        "//components/translate/content/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -573,17 +573,8 @@ static_library("ui") {
+@@ -579,17 +579,8 @@ static_library("ui") {
      "//components/reading_list/features:flags",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -61,7 +61,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search",
      "//components/search_engines",
-@@ -5681,7 +5672,6 @@ static_library("ui_public_dependencies")
+@@ -5716,7 +5707,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -71,7 +71,7 @@
      "//components/sync_user_events",
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -429,8 +429,12 @@ void DownloadProtectionService::ShowDeta
+@@ -426,8 +426,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -127,7 +127,7 @@
    static constexpr webui::LocalizedString kStrings[] = {
 --- a/chrome/browser/ui/views/download/download_danger_prompt_views.cc
 +++ b/chrome/browser/ui/views/download/download_danger_prompt_views.cc
-@@ -180,11 +180,15 @@ std::u16string DownloadDangerPromptViews
+@@ -178,11 +178,15 @@ std::u16string DownloadDangerPromptViews
                                          filename);
      case download::DOWNLOAD_DANGER_TYPE_UNCOMMON_CONTENT:
        return l10n_util::GetStringFUTF16(
@@ -162,7 +162,7 @@
      case download::DOWNLOAD_DANGER_TYPE_DANGEROUS_HOST:
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7117,13 +7117,9 @@ test("unit_tests") {
+@@ -7199,13 +7199,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -191,7 +191,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2284,15 +2284,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2311,15 +2311,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -209,7 +209,7 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7985,33 +7985,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8062,33 +8062,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
+++ b/patches/ungoogled-chromium/macos/fix-runTsc-log-info.patch
@@ -1,6 +1,6 @@
 --- a/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
 +++ b/third_party/devtools-frontend/src/scripts/build/typescript/ts_library.py
-@@ -56,7 +56,7 @@ logging.basicConfig(
+@@ -53,7 +53,7 @@ logging.basicConfig(
  
  def runTsc(tsconfig_location):
      cmd = [NODE_LOCATION, TSC_LOCATION, '-p', tsconfig_location]


### PR DESCRIPTION
https://github.com/ungoogled-software/ungoogled-chromium/pull/3288

- Downgraded node to match expected upstream version
- Added patch to disable clang warning suppression mappings (it might be a good idea to eventually bump llvm, but this PR is not about that)

other patches have no significant changes, builds and runs fine:

![image](https://github.com/user-attachments/assets/c61e3d2e-70dc-4af3-ae7c-212a30afd8a2)
