### PR TITLE
ci: Switch to use tarball when building.

### DIFF
--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -16,7 +16,7 @@ sudo du -hs "$_src_dir"
 rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -g "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -d -g "$_target_cpu"
 
 mkdir -p "$_src_dir/out/Default"
 
@@ -27,6 +27,6 @@ python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -p "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -d -p "$_target_cpu"
 
 rm -rvf "$_download_cache"


### PR DESCRIPTION
This should fix the issue that prevents us from building from git sources after #259.

P.S.: Sorry I pushed the branch to the wrong repo, apologies.