### PR TITLE
ci: Add More Resuming Building Jobs

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -641,3 +641,198 @@ jobs:
           path: |
             ./release_asset/${{ steps.bake.outputs.file_name }}
             ./${{ steps.bake.outputs.file_name }}.hashes.md
+
+  build_job_10:
+    name: Further Resuming Building Ungoogled-Chromium for macOS
+    runs-on: ${{ inputs.os }}
+    needs: build_job_09
+    if: ${{needs.build_job_09.outputs.status == 'running'}}
+    outputs:
+      status: ${{ steps.build.outputs.status }}
+    steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Copy GitHub specific scripts to git-root folder
+        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Disable spotlight
+        run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+      - name: Download resumed build
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+      - name: Setup Environment and Toolchain
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
+      - name: Unpack archive of build
+        run: ./github_unpack_archive.sh
+      - name: Resume Build
+        id: build
+        run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
+      - name: Prepare archive of build as artifact
+        id: bake
+        run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
+      - name: Upload part build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+          path: upload_part_build/
+          overwrite: true
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+          path: upload_logs/
+          overwrite: true
+      - name: Upload disk-image and hash file as artifact after build
+        if: ${{ steps.build.outputs.status == 'finished' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bake.outputs.file_name }}
+          path: |
+            ./release_asset/${{ steps.bake.outputs.file_name }}
+            ./${{ steps.bake.outputs.file_name }}.hashes.md
+
+build_job_11:
+    name: Further Resuming Building Ungoogled-Chromium for macOS
+    runs-on: ${{ inputs.os }}
+    needs: build_job_10
+    if: ${{needs.build_job_10.outputs.status == 'running'}}
+    outputs:
+      status: ${{ steps.build.outputs.status }}
+    steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Copy GitHub specific scripts to git-root folder
+        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Disable spotlight
+        run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+      - name: Download resumed build
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+      - name: Setup Environment and Toolchain
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
+      - name: Unpack archive of build
+        run: ./github_unpack_archive.sh
+      - name: Resume Build
+        id: build
+        run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
+      - name: Prepare archive of build as artifact
+        id: bake
+        run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
+      - name: Upload part build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+          path: upload_part_build/
+          overwrite: true
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+          path: upload_logs/
+          overwrite: true
+      - name: Upload disk-image and hash file as artifact after build
+        if: ${{ steps.build.outputs.status == 'finished' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bake.outputs.file_name }}
+          path: |
+            ./release_asset/${{ steps.bake.outputs.file_name }}
+            ./${{ steps.bake.outputs.file_name }}.hashes.md
+  
+  build_job_12:
+    name: Further Resuming Building Ungoogled-Chromium for macOS
+    runs-on: ${{ inputs.os }}
+    needs: build_job_11
+    if: ${{needs.build_job_11.outputs.status == 'running'}}
+    outputs:
+      status: ${{ steps.build.outputs.status }}
+    steps:
+      - name: Cleanup Xcode installations
+        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
+      - name: Select Xcode version
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Cleanup Xcode Simulators
+        run: sudo xcrun simctl delete all
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Copy GitHub specific scripts to git-root folder
+        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Disable spotlight
+        run: sudo mdutil -a -i off
+      - name: Run xcode-select
+        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
+      - name: Get previous logs
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+      - name: Download resumed build
+        uses: actions/download-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+      - name: Setup Environment and Toolchain
+        run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
+      - name: Unpack archive of build
+        run: ./github_unpack_archive.sh
+      - name: Resume Build
+        id: build
+        run: ./github_build.sh ${{ inputs.arch }} 2>&1 | tee -a github_actions_build_${{ inputs.arch }}.log
+      - name: Prepare archive of build as artifact
+        id: bake
+        run: ./github_prepare_artifacts.sh ${{ inputs.arch }} | tee -a github_actions_upload_${{ inputs.arch }}.log
+      - name: Upload part build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_artifact_${{ inputs.arch }}
+          path: upload_part_build/
+          overwrite: true
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: github_build_logs_${{ inputs.arch }}
+          path: upload_logs/
+          overwrite: true
+      - name: Upload disk-image and hash file as artifact after build
+        if: ${{ steps.build.outputs.status == 'finished' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.bake.outputs.file_name }}
+          path: |
+            ./release_asset/${{ steps.bake.outputs.file_name }}
+            ./${{ steps.bake.outputs.file_name }}.hashes.md

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -707,7 +707,7 @@ jobs:
             ./release_asset/${{ steps.bake.outputs.file_name }}
             ./${{ steps.bake.outputs.file_name }}.hashes.md
 
-build_job_11:
+  build_job_11:
     name: Further Resuming Building Ungoogled-Chromium for macOS
     runs-on: ${{ inputs.os }}
     needs: build_job_10
@@ -771,7 +771,7 @@ build_job_11:
           path: |
             ./release_asset/${{ steps.bake.outputs.file_name }}
             ./${{ steps.bake.outputs.file_name }}.hashes.md
-  
+
   build_job_12:
     name: Further Resuming Building Ungoogled-Chromium for macOS
     runs-on: ${{ inputs.os }}


### PR DESCRIPTION
[The release of 138.0.7204.157](https://github.com/ungoogled-software/ungoogled-chromium-macos/actions/runs/16354331790) just failed because the Intel build did not finish in time & all the "resume building" steps were used (as the timer preventing action timeout ran out of time). This adds a few extra steps and hopefully will temporarily solve the problem.