### PR TITLE
Update the link to binaries & main repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ungoogled-chromium-macos
 
-macOS packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium).
+macOS packaging for [ungoogled-chromium](//github.com/ungoogled-software/ungoogled-chromium).
 
 ## Downloads
 [Download binaries from GitHub Releases](//github.com/ungoogled-software/ungoogled-chromium-macos/releases).

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 macOS packaging for [ungoogled-chromium](//github.com/Eloston/ungoogled-chromium).
 
 ## Downloads
-
-[Download binaries from the Contributor Binaries website](//ungoogled-software.github.io/ungoogled-chromium-binaries/).
+[Download binaries from GitHub Releases](//github.com/ungoogled-software/ungoogled-chromium-macos/releases).
 
 Also available in [Homebrew](https://brew.sh/) as [ungoogled-chromium](https://formulae.brew.sh/cask/ungoogled-chromium). Just run `brew install --cask ungoogled-chromium`. Chromium will appear in your /Applications directory.
 


### PR DESCRIPTION
macos binaries are no longer pushed to [ungoogled-chromium-binaries](https://ungoogled-software.github.io/ungoogled-chromium-binaries/) (for at least 8 months now), so i think it's best to guide people to the latest releases on github instead