### PR TITLE
Update to ungoogled-chromium 141.0.7390.54

### DIFF
--- a/.github/scripts/github_before_build.sh
+++ b/.github/scripts/github_before_build.sh
@@ -24,6 +24,6 @@ cat "$_root_dir/flags.macos.gn" >> "$_src_dir/out/Default/args.gn"
 cd "$_src_dir"
 
 ./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
-./tools/rust/build_bindgen.py
+./tools/rust/build_bindgen.py --skip-test
 
 ./out/Default/gn gen out/Default --fail-on-unused-args

--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -16,7 +16,7 @@ sudo du -hs "$_src_dir"
 rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -d -g "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -g "$_target_cpu"
 
 mkdir -p "$_src_dir/out/Default"
 
@@ -27,6 +27,6 @@ python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -d -p "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -p "$_target_cpu"
 
 rm -rvf "$_download_cache"

--- a/.github/scripts/github_prepare_xcode.sh
+++ b/.github/scripts/github_prepare_xcode.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+shopt -s extglob
+
+sudo rm -rf /Applications/Xcode_!(26).app
+sudo xcode-select --switch /Applications/Xcode_26.app
+sudo xcrun simctl delete all
+xcodebuild -downloadComponent MetalToolchain

--- a/.github/scripts/github_prepare_xcode.sh
+++ b/.github/scripts/github_prepare_xcode.sh
@@ -6,4 +6,21 @@ shopt -s extglob
 sudo rm -rf /Applications/Xcode_!(26).app
 sudo xcode-select --switch /Applications/Xcode_26.app
 sudo xcrun simctl delete all
-xcodebuild -downloadComponent MetalToolchain
+
+if [ ! -e MetalToolchain.exportedBundle.tar.zst ]; then
+  echo "Downloading Metal Toolchain"
+  # this also installs the toolchain, so there's no need to separately import it (which would actually fail in this case).
+  xcodebuild -downloadComponent MetalToolchain -exportPath metal_toolchain
+  ls -lrt metal_toolchain
+  mv metal_toolchain/*.exportedBundle MetalToolchain.exportedBundle
+  rmdir metal_toolchain
+  # cache the bundle for future jobs (the next step will upload it in this case).
+  tar -c -f - MetalToolchain.exportedBundle | zstd -vv -11 -T0 -o MetalToolchain.exportedBundle.tar.zst
+else
+  echo "Extracting Metal Toolchain"
+  tar -xf MetalToolchain.exportedBundle.tar.zst
+  rm MetalToolchain.exportedBundle.tar.zst
+  xcodebuild -importComponent metalToolchain -importPath MetalToolchain.exportedBundle
+fi
+
+rm -rf MetalToolchain.exportedBundle

--- a/.github/scripts/github_setup_env_toolchain.sh
+++ b/.github/scripts/github_setup_env_toolchain.sh
@@ -4,5 +4,5 @@
 
 brew install ninja coreutils --overwrite
 
-# Install httplib2 for Python from PyPI
-pip3 install httplib2 --break-system-packages
+# Install PySocks and httplib2 for Python from PyPI
+pip3 install PySocks httplib2 --break-system-packages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,18 @@ jobs:
     name: Build macOS binaries of Ungoogled Chromium
     strategy:
       matrix:
-        arch: [arm64, x86_64]
+        include:
+          - arch: arm64
+            os: macos-15
+          - arch: x86_64
+            os: macos-15-intel
       fail-fast: true
       max-parallel: 2
     uses: ./.github/workflows/building.yml
     secrets: inherit
     with:
       arch: ${{ matrix.arch }}
-      os: macos-15
+      os: ${{ matrix.os }}
 
   release:
     needs: build

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -28,20 +28,16 @@ jobs:
     name: Retrieve resources required for building
     runs-on: ${{ inputs.os }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
       - name: Setup Environment and Toolchain
@@ -65,24 +61,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Setup Environment and Toolchain
         run: ./github_setup_env_toolchain.sh ${{ inputs.arch }} | tee -a github_actions_setup_env_toolchain.log
       - name: Download resources
@@ -130,24 +120,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -195,24 +179,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -260,24 +238,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -325,24 +297,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -390,24 +356,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -455,24 +415,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -520,24 +474,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -585,24 +533,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -650,24 +592,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -715,24 +651,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:
@@ -780,24 +710,18 @@ jobs:
     outputs:
       status: ${{ steps.build.outputs.status }}
     steps:
-      - name: Cleanup Xcode installations
-        run: sudo mv /Applications/Xcode_16.4.app /Applications/tmp_Xcode_16.4.app ; sudo rm -rf /Applications/Xcode* ; sudo mv /Applications/tmp_Xcode_16.4.app /Applications/Xcode_16.4.app
-      - name: Select Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
-      - name: Cleanup Xcode Simulators
-        run: sudo xcrun simctl delete all
-      - name: Cleanup Android Related Stuff
-        run: sudo rm -rf $ANDROID_HOME
       - name: Clone repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Cleanup Android Related Stuff
+        run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
         run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+      - name: Prepare Xcode
+        run: ./github_prepare_xcode.sh
       - name: Disable spotlight
         run: sudo mdutil -a -i off
-      - name: Run xcode-select
-        run: sudo xcode-select --switch /Applications/Xcode_16.4.app
       - name: Get previous logs
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -38,6 +38,11 @@ jobs:
         run: cp -va ./.github/scripts/ ./
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
+      - name: Upload Metal Toolchain
+        uses: actions/upload-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
+          path: MetalToolchain.exportedBundle.tar.zst
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
       - name: Setup Environment and Toolchain
@@ -65,10 +70,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable Spotlight
@@ -124,10 +135,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -183,10 +200,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -242,10 +265,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -301,10 +330,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -360,10 +395,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -419,10 +460,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -478,10 +525,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -537,10 +590,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -596,10 +655,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -655,10 +720,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight
@@ -714,10 +785,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Log Start Timestamp
+        run: date +%s > ./epoch_job_start.txt
       - name: Cleanup Android Related Stuff
         run: sudo rm -rf $ANDROID_HOME
       - name: Copy GitHub specific scripts to git-root folder
-        run: cp -va ./.github/scripts/ ./ ; date +%s > ./epoch_job_start.txt
+        run: cp -va ./.github/scripts/ ./
+      - name: Download Metal Toolchain
+        uses: actions/download-artifact@v4
+        with:
+          name: metal_toolchain_${{ inputs.arch }}
       - name: Prepare Xcode
         run: ./github_prepare_xcode.sh
       - name: Disable spotlight

--- a/README.md
+++ b/README.md
@@ -69,16 +69,13 @@ Note that these sponsorship accounts are under the name of `Qubik65536`. All spo
 ### Setting up the build environment
 
 1. Install Python 3 via Homebrew: `brew install python@3`
-2. Install `httplib2` via `pip3`: `pip3 install httplib2`, note that you might need to use `--break-system-packages` if you don't want to use a dedicated Python environment for building Ungoogled-Chromium.
-3. Install LLVM via Homebrew: `brew install llvm`, and set `LDFLAGS` and `CPPFLAGS` environment variables according to the Homebrew prompt.
+2. Install `PySocks` and `httplib2` via `pip3`: `pip3 install PySocks httplib2`, note that you might need to use `--break-system-packages` if you don't want to use a dedicated Python environment for building Ungoogled-Chromium.
+3. Install Metal toolchain: `xcodebuild -downloadComponent MetalToolchain`
 4. Install Ninja via Homebrew: `brew install ninja`
 5. Install GNU coreutils and readline via Homebrew: `brew install coreutils readline`
-6. Install the data compression tools xz and zlib via Homebrew: `brew install xz zlib`
-7. Unlink binutils to use the one provided with Xcode: `brew unlink binutils`
-8. Install Node.js via Homebrew: `brew install node`
-9. Restart your terminal.
-
-**NOTE**: If you are building for x86_64 Mac from an Apple Silicon (arm64) Mac, you might need to install Rosetta 2 and these tools from x86_64 Homebrew, as well as setting `PATH` variables to use the x86_64 tools.
+6. Unlink binutils to use the one provided with Xcode: `brew unlink binutils`
+7. Install Node.js via Homebrew: `brew install node`
+8. Restart your terminal.
 
 ### Build
 

--- a/build.sh
+++ b/build.sh
@@ -60,7 +60,7 @@ mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 cd "$_src_dir"
 
 ./tools/gn/bootstrap/bootstrap.py -o out/Default/gn --skip-generate-buildfiles
-./tools/rust/build_bindgen.py
+./tools/rust/build_bindgen.py --skip-test
 
 ./out/Default/gn gen out/Default --fail-on-unused-args
 

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -2,11 +2,11 @@
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = bd809ffb4b5f277a661509fbbbf9ea893a545ab0
-url = https://github.com/dumbmoron/llvm-macos-buildbot/releases/download/%(version)s-arm64/clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
+version = 21.1.0
+url = https://github.com/implicitfield/llvm-macos-buildbot/releases/download/%(version)s-arm64/clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-arm64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-arm64-apple-darwin21.0
-sha512 = 64ebdb038a8e0444e50032951775e75e40ae7a8cc8cdaa3d5148060666419ffee0d4579e9a400f5f945bd4e7e2540ff65e650df54eaada4f17eea75de3a4e0df
+sha512 = da21c5f7d77687136f3e198be844a07cf60df7d1f39d1ae4a3e4881eeb1c20831ede87c3a4a781d822b167307170af3d1236a1b9eb910eb0ebbd425a9d0eb8ae
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -2,11 +2,11 @@
 
 # Pre-built LLVM toolchain for convenience
 [llvm]
-version = bd809ffb4b5f277a661509fbbbf9ea893a545ab0
-url = https://github.com/dumbmoron/llvm-macos-buildbot/releases/download/%(version)s-x86-64/clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
+version = 21.1.0
+url = https://github.com/implicitfield/llvm-macos-buildbot/releases/download/%(version)s-x86-64/clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 download_filename = clang+llvm-%(version)s-x86-64-apple-darwin21.0.tar.xz
 strip_leading_dirs = clang+llvm-%(version)s-x86-64-apple-darwin21.0
-sha512 = 979e514bb1741e1871128ed4dcdf600d97e48aaa746e337f246b1dd9f30a0f88833c02f31cefe507784108eeee854b3e611ad94bf4a22212dbd5fb7fe2875b11
+sha512 = 12f8df0091cd1ee427afa31c710e9a52a20c2a0087537e98bb4033f650b7fc53a2f55ce5ed389f87103b9fefe7d42a4cb0e33b8daa6abffd54c8dcd1be4b6168
 output_path = third_party/llvm-build/Release+Asserts
 
 [nodejs]

--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,5 @@ ungoogled-chromium/macos/fix-runTsc-log-info.patch
 ungoogled-chromium/macos/no-unknown-warnings.patch
 ungoogled-chromium/macos/re2-include-fix
 ungoogled-chromium/macos/build-bindgen-target-override.patch
+ungoogled-chromium/macos/bindgen-disable-static.patch
+ungoogled-chromium/macos/handle-unbundled-metal-toolchain.patch

--- a/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
+++ b/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
@@ -1,0 +1,18 @@
+--- a/tools/rust/build_bindgen.py
++++ b/tools/rust/build_bindgen.py
+@@ -191,14 +191,13 @@ def main():
+         RmTree(build_dir)
+ 
+     print(f'Building bindgen in {build_dir} ...')
+-    static_feature = ",static" if ('windows' not in RustTargetTriple()) else ""
+     cargo_args = [
+         'build',
+         f'--manifest-path={BINDGEN_SRC_DIR}/Cargo.toml',
+         f'--target-dir={build_dir}',
+         f'--target={rust_target}',
+         f'--no-default-features',
+-        f'--features=logging' + static_feature,
++        f'--features=logging',
+         '--release',
+         '--bin',
+         'bindgen',

--- a/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
@@ -1,6 +1,6 @@
 --- a/tools/rust/build_bindgen.py
 +++ b/tools/rust/build_bindgen.py
-@@ -173,11 +173,18 @@ def main():
+@@ -166,6 +166,12 @@ def main():
          '--skip-checkout',
          action='store_true',
          help='skip downloading the git repo. Useful for trying local changes')
@@ -10,8 +10,10 @@
 +        type=str,
 +        default=RustTargetTriple(),
 +        help='The Rust target triple to build bindgen for')
-     args, rest = parser.parse_known_args()
- 
+     parser.add_argument('--skip-test',
+                         action='store_true',
+                         help='skip running tests')
+@@ -174,6 +180,7 @@ def main():
      if not args.skip_checkout:
          CheckoutGitRepo("bindgen", BINDGEN_GIT_REPO, BINDGEN_GIT_VERSION,
                          BINDGEN_SRC_DIR)
@@ -19,7 +21,7 @@
  
      build_dir = BINDGEN_HOST_BUILD_DIR
      if os.path.exists(build_dir):
-@@ -189,7 +196,7 @@ def main():
+@@ -185,7 +192,7 @@ def main():
          'build',
          f'--manifest-path={BINDGEN_SRC_DIR}/Cargo.toml',
          f'--target-dir={build_dir}',
@@ -28,7 +30,7 @@
          f'--no-default-features',
          f'--features=logging' + static_feature,
          '--release',
-@@ -203,7 +210,7 @@ def main():
+@@ -199,7 +206,7 @@ def main():
  
      llvm_dir = os.path.join(THIRD_PARTY_DIR, 'llvm-build', 'Release+Asserts')
      shutil.copy(
@@ -39,7 +41,7 @@
          shutil.copy(os.path.join(llvm_dir, 'bin', f'libclang.dll'),
 --- a/build/rust/rust_bindgen_generator.gni
 +++ b/build/rust/rust_bindgen_generator.gni
-@@ -177,7 +177,7 @@ template("rust_bindgen_generator") {
+@@ -171,7 +171,7 @@ template("rust_bindgen_generator") {
        ]
      }
  

--- a/patches/ungoogled-chromium/macos/build-bindgen.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen.patch
@@ -2,15 +2,15 @@
 +++ b/tools/rust/build_bindgen.py
 @@ -29,8 +29,7 @@ from update import (RmTree)
  # The git hash to use.  See https://github.com/rust-lang/rust-bindgen/tags.
- # The current hash below corresponds to version 0.72.0
- BINDGEN_GIT_VERSION = 'd0e7d6b5b763e93dd38f9ece05230979ede95a0a'
+ # The current hash below corresponds to something between 0.72.0 and 0.73.0.
+ BINDGEN_GIT_VERSION = '2426dd68cd12e0ac022bca18efb9c7d0acd27e12'
 -BINDGEN_GIT_REPO = ('https://chromium.googlesource.com/external/' +
 -                    'github.com/rust-lang/rust-bindgen')
 +BINDGEN_GIT_REPO = ('https://github.com/rust-lang/rust-bindgen')
  
  BINDGEN_SRC_DIR = os.path.join(THIRD_PARTY_DIR, 'rust-toolchain-intermediate',
                                 'bindgen-src')
-@@ -103,15 +102,8 @@ def RunCargo(cargo_args):
+@@ -96,15 +95,8 @@ def RunCargo(cargo_args):
                f'the build_rust.py script builds rustc that is needed here.')
          sys.exit(1)
  
@@ -28,7 +28,7 @@
  
      env = collections.defaultdict(str, os.environ)
      # Cargo normally stores files in $HOME. Override this.
-@@ -209,7 +201,7 @@ def main():
+@@ -205,7 +197,7 @@ def main():
      install_dir = os.path.join(RUST_TOOLCHAIN_OUT_DIR)
      print(f'Installing bindgen to {install_dir} ...')
  

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1713,8 +1713,7 @@ config("compiler_deterministic") {
+@@ -1706,8 +1706,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-warning-suppression.patch
+++ b/patches/ungoogled-chromium/macos/disable-warning-suppression.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -347,7 +347,6 @@ config("compiler") {
+@@ -342,7 +342,6 @@ config("compiler") {
      ":compiler_cpu_abi",
      ":compiler_codegen",
      ":compiler_deterministic",

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -292,8 +292,6 @@ clang_lib("compiler_builtins") {
+@@ -248,8 +248,6 @@ clang_lib("compiler_builtins") {
      } else {
        assert(false, "unsupported target_platform=$target_platform")
      }

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1770,10 +1770,6 @@ static_library("browser") {
+@@ -1738,10 +1738,6 @@ static_library("browser") {
      "//chrome/browser/prefs:util_impl",
      "//chrome/browser/profiles:profiles_extra_parts_impl",
      "//chrome/browser/profiles:profile_util_impl",
@@ -13,8 +13,8 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -2011,7 +2007,6 @@ static_library("browser") {
-     "//chrome/browser/reading_list",
+@@ -1989,7 +1985,6 @@ static_library("browser") {
+     "//chrome/browser/regional_capabilities:metrics_provider_impl",
      "//chrome/browser/resource_coordinator:tab_manager_features",
      "//chrome/browser/resources/accessibility:resources",
 -    "//chrome/browser/safe_browsing",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -841,9 +841,6 @@ source_set("extensions") {
+@@ -845,9 +845,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -881,7 +878,6 @@ source_set("extensions") {
+@@ -886,7 +883,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -43,7 +43,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -548,17 +548,8 @@ static_library("ui") {
+@@ -539,17 +539,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -61,7 +61,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5518,7 +5509,6 @@ static_library("ui_public_dependencies")
+@@ -5329,7 +5320,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -71,7 +71,7 @@
      "//components/sync_user_events",
 --- a/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
 +++ b/chrome/browser/safe_browsing/download_protection/download_protection_service.cc
-@@ -378,8 +378,12 @@ void DownloadProtectionService::ShowDeta
+@@ -383,8 +383,12 @@ void DownloadProtectionService::ShowDeta
    Profile* profile = Profile::FromBrowserContext(
        content::DownloadItemUtils::GetBrowserContext(item));
    if (profile &&
@@ -146,7 +146,7 @@
        return l10n_util::GetStringFUTF16(IDS_PROMPT_DOWNLOAD_CHANGES_SETTINGS,
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7559,13 +7559,9 @@ test("unit_tests") {
+@@ -7626,13 +7626,9 @@ test("unit_tests") {
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/browser/updater:browser_updater_client",
        "//chrome/common/notifications",
@@ -175,7 +175,7 @@
        "safe_archive_analyzer.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2323,15 +2323,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2327,15 +2327,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -193,7 +193,7 @@
      lens::prefs::kLensOverlaySettings,
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7742,33 +7742,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -7923,33 +7923,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/handle-unbundled-metal-toolchain.patch
+++ b/patches/ungoogled-chromium/macos/handle-unbundled-metal-toolchain.patch
@@ -1,0 +1,88 @@
+--- a/third_party/angle/src/libANGLE/renderer/metal/BUILD.gn
++++ b/third_party/angle/src/libANGLE/renderer/metal/BUILD.gn
+@@ -24,20 +24,56 @@ config("angle_metal_backend_config") {
+ }
+ 
+ if (metal_internal_shader_compilation_supported) {
++  template("run_metal_tool") {
++    action(target_name) {
++      forward_variables_from(invoker,
++                             [
++                               "deps",
++                               "sources",
++                               "outputs",
++                               "metal_tool",
++                             ])
++      script = "shaders/metal_wrapper.py"
++      if (use_system_xcode) {
++        # System Xcode: run metal and metallib via xcrun. Since Xcode 26.0, the
++        # Metal toolchain has been unbundled from Xcode, and must be installed
++        # separately by running `xcodebuild -downloadComponent MetalToolchain`.
++        # There is a vestigial metal executable in mac_bin_path, but it’s
++        # incapable of running successfuly without the
++        # rest of the Metal toolchain surrounding it. `xcrun` is able to find
++        # and run the correct Metal toolchain when properly installed.
++        #
++        # If you’re using system Xcode and your build fails with this message:
++        #   error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
++        # then do what the error message suggests, and then retry your build.
++        args = [
++          "xcrun",
++          metal_tool,
++        ]
++      } else {
++        # Hermetic Xcode: at least for now, the Metal toolchain is
++        # “spliced” into the location in the hermetic toolchain where it lived
++        # before Xcode 26.0, so it can be run directly from there.
++        args = [ mac_bin_path + metal_tool ]
++      }
++
++      args += invoker.args
++    }
++  }
++
+   _metal_internal_shaders_air_file =
+       "$root_gen_dir/angle/mtl_internal_shaders_autogen.air"
+ 
+-  action("angle_metal_internal_shaders_to_air") {
+-    script = "shaders/metal_wrapper.py"
+-
+-    outputs = [ _metal_internal_shaders_air_file ]
+-
++  run_metal_tool("angle_metal_internal_shaders_to_air") {
+     _metal_internal_shaders_metal_source =
+         "shaders/mtl_internal_shaders_autogen.metal"
+     sources = [ _metal_internal_shaders_metal_source ]
+ 
++    outputs = [ _metal_internal_shaders_air_file ]
++
++    metal_tool = "metal"
++
+     args = [
+-      mac_bin_path + "metal",
+       "-c",
+       rebase_path(_metal_internal_shaders_metal_source, root_build_dir),
+       "-o",
+@@ -60,17 +96,16 @@ if (metal_internal_shader_compilation_supported) {
+   _metal_internal_shaders_metallib_file =
+       "$root_gen_dir/angle/mtl_internal_shaders_autogen.metallib"
+ 
+-  action("angle_metal_internal_shaders_to_mtllib") {
+-    script = "shaders/metal_wrapper.py"
+-
+-    outputs = [ _metal_internal_shaders_metallib_file ]
++  run_metal_tool("angle_metal_internal_shaders_to_mtllib") {
++    deps = [ ":angle_metal_internal_shaders_to_air" ]
+ 
+     sources = [ _metal_internal_shaders_air_file ]
+ 
+-    deps = [ ":angle_metal_internal_shaders_to_air" ]
++    outputs = [ _metal_internal_shaders_metallib_file ]
++
++    metal_tool = "metallib"
+ 
+     args = [
+-      mac_bin_path + "metallib",
+       rebase_path(_metal_internal_shaders_air_file, root_build_dir),
+       "-o",
+       rebase_path(_metal_internal_shaders_metallib_file, root_build_dir),


### PR DESCRIPTION
Notes:
- Toolchain stuff can be reverted again, that's just in this PR because this is what I'm using locally (I'm not sure why upstream wants to link bindgen statically anyway, this really seems quite inconsequential).
- Updated to Xcode 26 since that's what most people probably use locally.
- Imported [2f564f1](https://chromium.googlesource.com/angle/angle/+/2f564f1ca07b1d2668d8639d98ea5ad51cc9cd35) from upstream (as `handle-unbundled-metal-toolchain.patch`) since that didn't make it to the 141 branch and Xcode 26 doesn't work without that.
- This tries to build x86_64 binaries natively again. I'm currently testing this in my own repository to see if this is any faster. If it isn't, then I'll drop that change before marking this as ready.
- PySocks is now installed, and git is once more used to fetch chromium (hopefully upstream doesn't randomly break that again).
- Removed some unneeded dependencies from the README (I'm not sure if node is needed either since that's included in the `downloads-$arch.ini` files, but I have that installed, so I can't tell).
- `bindgen` tests are now skipped, since those are kind of a waste of CI time.
- This seems to trigger https://github.com/llvm/llvm-project/issues/109549 now. Might be due to the Xcode update, or maybe a libcxx roll upstream.