### PR TITLE
Read symlinks when looking for Xcode

### DIFF
--- a/.github/scripts/github_prepare_xcode.sh
+++ b/.github/scripts/github_prepare_xcode.sh
@@ -36,7 +36,7 @@ if [ ! -e MetalToolchain.exportedBundle.tar.zst ]; then
   rmdir metal_toolchain
   # cache the bundle for future jobs (the next step will upload it in this case).
   tar -c -f - MetalToolchain.exportedBundle | zstd -vv -11 -T0 -o MetalToolchain.exportedBundle.tar.zst
-else
+elif [ "$(xcodebuild -showComponent metalToolchain | grep 'Status: ')" != "Status: installed" ]; then
   echo "Extracting Metal Toolchain"
   tar -xf MetalToolchain.exportedBundle.tar.zst
   rm MetalToolchain.exportedBundle.tar.zst


### PR DESCRIPTION
Different jobs are currently getting different runner images that don't have any versions of Xcode 26 in common. This PR tries to deal with that, but I can't guarantee that this'll work since the runner might end up getting either Xcode 26.0.0 or Xcode 26.0.1.

The other options would be to:
- cache the entire Xcode toolchain (not sure how well that would work in practice though)
- wait until the runners images settle down again (might take some time)
- downgrade to Xcode 15 (though Xcode 26+ will probably be needed in future Chromium releases, and this would involve reverting/disabling all the Metal Toolchain stuff).