### PR TITLE
ci: Rollback Python to 3.13 (required for `depot_tools`)

### DIFF
--- a/.github/workflows/building.yml
+++ b/.github/workflows/building.yml
@@ -40,7 +40,7 @@ jobs:
         run: ./github_prepare_xcode.sh
       - name: Disable Spotlight
         run: sudo mdutil -a -i off
-      - name: Setup Python 3.8 (Needed for depot_tools)
+      - name: Setup Python 3.13 (latest for depot_tools to work)
         uses: actions/setup-python@v3
         with:
           python-version: "3.13"


### PR DESCRIPTION
Recently, the Python version in the GitHub Action runners were bumped to 3.14, which caused errors with depot_tools (see [action run 18660614656](https://github.com/ungoogled-software/ungoogled-chromium-macos/actions/runs/18660614656)). Rolling back to 3.13 solves this.

A (partially) successful downstream test run: https://github.com/iXORTech/ungoogled-chromium-macos/actions/runs/18665101605