### PR TITLE
Update to ungoogled-chromium 147.0.7727.55

### DIFF
--- a/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
+++ b/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
@@ -1,14 +1,12 @@
 --- a/tools/rust/build_bindgen.py
 +++ b/tools/rust/build_bindgen.py
-@@ -187,14 +187,13 @@ def main():
-         RmTree(build_dir)
- 
-     print(f'Building bindgen in {build_dir} ...')
+@@ -197,12 +197,11 @@ def main():
+     RunCargo([
+         'clean',
+     ] + cargo_shared_args)
 -    static_feature = ",static" if ('windows' not in RustTargetTriple()) else ""
      cargo_args = [
          'build',
-         f'--manifest-path={BINDGEN_SRC_DIR}/Cargo.toml',
-         f'--target-dir={build_dir}',
          f'--target={rust_target}',
          f'--no-default-features',
 -        f'--features=logging' + static_feature,

--- a/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
@@ -21,16 +21,16 @@
  
      build_dir = BINDGEN_HOST_BUILD_DIR
      if os.path.exists(build_dir):
-@@ -185,7 +192,7 @@ def main():
+@@ -193,7 +200,7 @@ def main():
+     static_feature = ",static" if ('windows' not in RustTargetTriple()) else ""
+     cargo_args = [
          'build',
-         f'--manifest-path={BINDGEN_SRC_DIR}/Cargo.toml',
-         f'--target-dir={build_dir}',
 -        f'--target={RustTargetTriple()}',
 +        f'--target={rust_target}',
          f'--no-default-features',
          f'--features=logging' + static_feature,
          '--release',
-@@ -199,7 +206,7 @@ def main():
+@@ -207,7 +214,7 @@ def main():
  
      llvm_dir = os.path.join(THIRD_PARTY_DIR, 'llvm-build', 'Release+Asserts')
      shutil.copy(

--- a/patches/ungoogled-chromium/macos/build-bindgen.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen.patch
@@ -2,8 +2,8 @@
 +++ b/tools/rust/build_bindgen.py
 @@ -29,8 +29,7 @@ from update import (RmTree)
  # The git hash to use.  See https://github.com/rust-lang/rust-bindgen/tags.
- # The current hash below corresponds to something between 0.72.0 and 0.73.0.
- BINDGEN_GIT_VERSION = '2426dd68cd12e0ac022bca18efb9c7d0acd27e12'
+ # The current hash below corresponds to 0.72.1
+ BINDGEN_GIT_VERSION = 'd874de8d646d9b8a3e7ba2db2bcd52f2fba8f1f5'
 -BINDGEN_GIT_REPO = ('https://chromium.googlesource.com/external/' +
 -                    'github.com/rust-lang/rust-bindgen')
 +BINDGEN_GIT_REPO = ('https://github.com/rust-lang/rust-bindgen')
@@ -28,7 +28,7 @@
  
      env = collections.defaultdict(str, os.environ)
      # Cargo normally stores files in $HOME. Override this.
-@@ -205,7 +197,7 @@ def main():
+@@ -213,7 +205,7 @@ def main():
      install_dir = os.path.join(RUST_TOOLCHAIN_OUT_DIR)
      print(f'Installing bindgen to {install_dir} ...')
  

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1735,8 +1735,7 @@ config("compiler_deterministic") {
+@@ -1760,8 +1760,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
+++ b/patches/ungoogled-chromium/macos/disable-crashpad-handler.patch
@@ -2,10 +2,10 @@
 
 --- a/third_party/crashpad/crashpad/client/crashpad_client_mac.cc
 +++ b/third_party/crashpad/crashpad/client/crashpad_client_mac.cc
-@@ -138,61 +138,7 @@ class HandlerStarter final : public Noti
-       const std::map<std::string, std::string>& annotations,
+@@ -139,62 +139,7 @@ class HandlerStarter final : public Noti
        const std::vector<std::string>& arguments,
-       bool restartable) {
+       bool restartable,
+       const std::vector<base::FilePath>& attachments) {
 -    base::apple::ScopedMachReceiveRight receive_right(
 -        NewMachPort(MACH_PORT_RIGHT_RECEIVE));
 -    if (!receive_right.is_valid()) {
@@ -46,13 +46,14 @@
 -                     arguments,
 -                     std::move(receive_right),
 -                     handler_restarter.get(),
--                     false)) {
+-                     false,
+-                     attachments)) {
 -      return base::apple::ScopedMachSendRight();
 -    }
 -
--    if (handler_restarter &&
--        handler_restarter->StartRestartThread(
--            handler, database, metrics_dir, url, annotations, arguments)) {
+-    if (handler_restarter && handler_restarter->StartRestartThread(
+-                                 handler, database, metrics_dir, url,
+-                                 annotations, arguments, attachments)) {
 -      // The thread owns the object now.
 -      std::ignore = handler_restarter.release();
 -    }
@@ -65,10 +66,10 @@
    }
  
    // NotifyServer::DefaultInterface:
-@@ -463,24 +409,7 @@ bool CrashpadClient::StartHandler(
-   // Attachments are not implemented on MacOS yet.
-   DCHECK(attachments.empty());
- 
+@@ -470,25 +415,7 @@ bool CrashpadClient::StartHandler(
+     bool restartable,
+     bool asynchronous_start,
+     const std::vector<base::FilePath>& attachments) {
 -  // The “restartable” behavior can only be selected on OS X 10.10 and later. In
 -  // previous OS versions, if the initial client were to crash while attempting
 -  // to restart the handler, it would become an unkillable process.
@@ -80,7 +81,8 @@
 -      annotations,
 -      arguments,
 -      restartable && (__MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_10 ||
--                      MacOSVersionNumber() >= 10'10'00)));
+-                      MacOSVersionNumber() >= 10'10'00),
+-      attachments));
 -  if (!exception_port.is_valid()) {
 -    return false;
 -  }

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1226,7 +1226,7 @@ if (is_win) {
+@@ -1235,7 +1235,7 @@ if (is_win) {
  
    # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -1,6 +1,16 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1879,18 +1879,6 @@ config("sanitize_c_array_bounds") {
+@@ -616,9 +616,6 @@ config("compiler") {
+     # The performance improvement does not seem worth the risk. See
+     # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
+     # for discussion.
+-    if (!is_wasm) {
+-      cflags += [ "-fno-lifetime-dse" ]
+-    }
+ 
+     # TODO(hans): Remove this once Clang generates better optimized debug info
+     # by default. https://crbug.com/765793
+@@ -1879,18 +1876,6 @@ config("sanitize_c_array_bounds") {
      cflags = [
        "-fsanitize=array-bounds",
        "-fsanitize-trap=array-bounds",

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1854,18 +1854,6 @@ config("sanitize_c_array_bounds") {
+@@ -1879,18 +1879,6 @@ config("sanitize_c_array_bounds") {
      cflags = [
        "-fsanitize=array-bounds",
        "-fsanitize-trap=array-bounds",

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -261,8 +261,6 @@ clang_lib("compiler_builtins") {
+@@ -264,8 +264,6 @@ clang_lib("compiler_builtins") {
      } else {
        assert(false, "unsupported target_platform=$target_platform")
      }

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1560,10 +1560,6 @@ static_library("browser") {
+@@ -1410,10 +1410,6 @@ static_library("browser") {
      "//chrome/browser/prefs:util_impl",
      "//chrome/browser/profiles:profiles_extra_parts_impl",
      "//chrome/browser/profiles:profile_util_impl",
@@ -13,7 +13,7 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -1898,7 +1894,6 @@ static_library("browser") {
+@@ -1821,7 +1817,6 @@ static_library("browser") {
      "//chrome/browser/regional_capabilities",
      "//chrome/browser/regional_capabilities:metrics_provider_impl",
      "//chrome/browser/resources/accessibility:resources",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -851,9 +851,6 @@ source_set("extensions") {
+@@ -854,9 +854,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -887,7 +884,6 @@ source_set("extensions") {
+@@ -890,7 +887,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -43,7 +43,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -547,18 +547,8 @@ static_library("ui") {
+@@ -573,18 +573,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -62,7 +62,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5509,7 +5499,6 @@ static_library("ui_public_dependencies")
+@@ -5548,7 +5538,6 @@ static_library("ui_public_dependencies")
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -103,7 +103,7 @@
                ? IDS_PROMPT_UNCOMMON_DOWNLOAD_CONTENT_IN_ADVANCED_PROTECTION
 --- a/chrome/browser/ui/webui/downloads/downloads_ui.cc
 +++ b/chrome/browser/ui/webui/downloads/downloads_ui.cc
-@@ -39,6 +39,7 @@
+@@ -40,6 +40,7 @@
  #include "components/history/core/common/pref_names.h"
  #include "components/prefs/pref_service.h"
  #include "components/profile_metrics/browser_profile_type.h"
@@ -111,7 +111,7 @@
  #include "components/strings/grit/components_strings.h"
  #include "content/public/browser/download_manager.h"
  #include "content/public/browser/url_data_source.h"
-@@ -67,10 +68,12 @@ content::WebUIDataSource* CreateAndAddDo
+@@ -68,10 +69,12 @@ content::WebUIDataSource* CreateAndAddDo
    webui::SetupWebUIDataSource(source, kDownloadsResources,
                                IDR_DOWNLOADS_DOWNLOADS_HTML);
  
@@ -160,7 +160,7 @@
        "obfuscated_archive_analysis_delegate.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2384,15 +2384,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2374,15 +2374,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -178,7 +178,7 @@
      ash::prefs::kAuthenticationFlowAutoReloadInterval,
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7844,8 +7844,6 @@ test("unit_tests") {
+@@ -7904,8 +7904,6 @@ test("unit_tests") {
        "//chrome/browser/apps/app_shim",
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/common/notifications",
@@ -189,7 +189,7 @@
        "//chrome/utility/safe_browsing",
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -7997,33 +7997,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8103,33 +8103,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));


### PR DESCRIPTION
Minor updates to some of the patches were required.

Upstream introduced the `-fno-lifetime-dse` CFLAG in [[7573900]](https://chromium-review.googlesource.com/c/chromium/src/+/7573900) that has not yet been included in a stable clang release, so it needs to be removed in order to build with our version of LLVM.

Not yet tested as local build is ongoing.

The corresponding upstream release fixes several [CVEs](https://chromereleases.googleblog.com/2026/04/stable-channel-update-for-desktop.html) including two that are flagged _critical_ and that allow for remote code execution