### PR TITLE
Add patch to disable Glic Actor on non-Google builds (fixes macOS Tahoe startup crash)

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
+ungoogled-chromium/macos/fix-startup-crash-tahoe.patch
 ungoogled-chromium/macos/build-bindgen.patch
 ungoogled-chromium/macos/disable-clang-version-check.patch
 ungoogled-chromium/macos/disable-crashpad-handler.patch

--- a/patches/ungoogled-chromium/macos/fix-startup-crash-tahoe.patch
+++ b/patches/ungoogled-chromium/macos/fix-startup-crash-tahoe.patch
@@ -1,0 +1,36 @@
+# Disable Glic (Google AI Actor) for ungoogled-chromium builds
+#
+# kGlicActor is ENABLED_BY_DEFAULT on non-Android but requires Google-internal
+# services absent in ungoogled builds, causing two crashes:
+#
+# 1. BrowserView init: ActorTaskListBubbleController calls
+#    GlicActorTaskIconManagerFactory::GetForProfile -> GlicActorTaskIconManager(
+#    profile, actor_service=null) -> CHECK(actor_service) fires.
+#
+# 2. chrome://settings: AddGlicStrings -> ShouldShowWebActuationToggle accesses
+#    GlicKeyedService::actor_policy_checker() which is uninitialized when
+#    kGlicActor is disabled -> EXC_BAD_ACCESS at offset 0xac.
+
+--- a/chrome/common/chrome_features.cc
++++ b/chrome/common/chrome_features.cc
+@@ -264,7 +264,7 @@ BASE_FEATURE(kForcedAppRelaunchOnPlaceholderUpdate,
+ BASE_FEATURE(kGeoLanguage, base::FEATURE_DISABLED_BY_DEFAULT);
+
+ // Controls whether the actor component of Glic is enabled.
+-#if BUILDFLAG(IS_ANDROID)
++#if BUILDFLAG(IS_ANDROID) || !BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ BASE_FEATURE(kGlicActor, base::FEATURE_DISABLED_BY_DEFAULT);
+ #else
+ BASE_FEATURE(kGlicActor, base::FEATURE_ENABLED_BY_DEFAULT);
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -747,6 +747,9 @@ bool IsWebActuationDisabledForEnterprise(Profile* profile) {
+ }
+
+ bool ShouldShowWebActuationToggle(Profile* profile) {
++  if (!base::FeatureList::IsEnabled(features::kGlicActor)) {
++    return false;
++  }
+   auto* command_line = base::CommandLine::ForCurrentProcess();
+   if (command_line->HasSwitch(::switches::kGlicAlwaysShowWebActuationToggle)) {
+     return true;


### PR DESCRIPTION
## Summary

Fixes two crashes on **macOS Tahoe (26.x)** caused by `kGlicActor` being `FEATURE_ENABLED_BY_DEFAULT` on non-Android platforms while requiring Google-internal services absent in ungoogled builds.

### Crash 1 — BrowserView initialization (`EXC_BREAKPOINT`)

`ActorTaskListBubbleController` is unconditionally instantiated during `BrowserWindowFeatures::InitPostBrowserViewConstruction()` when `kGlicActor` is enabled. It calls `GlicActorTaskIconManagerFactory::GetForProfile()` which constructs `GlicActorTaskIconManager(profile, actor_service)` — but `actor_service` (from `ActorKeyedServiceFactory`) is **null** without the Google backend → `CHECK(actor_service)` fires → `brk #0`.

### Crash 2 — `chrome://settings` (`EXC_BAD_ACCESS`)

Opening About Chromium (or any settings page) triggers `AddLocalizedStrings` → `AddGlicStrings` → `ShouldShowWebActuationToggle`, which calls `glic_service->actor_policy_checker().CannotActOnWebReason()`. The `actor_policy_checker_` member is uninitialized when `kGlicActor` is disabled → null dereference at offset `0xac`.

## Fix

Two minimal changes:

1. **`chrome/common/chrome_features.cc`** — disable `kGlicActor` on `!GOOGLE_CHROME_BRANDING` builds (same as Android)
2. **`chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc`** — guard `ShouldShowWebActuationToggle` with a `kGlicActor` feature check before accessing the actor policy checker

## Test plan

- [x] Chromium launches without crash on macOS 26.4.1 (25E253)
- [x] `chrome://settings/help` (About Chromium) opens without crash
- [x] `kDestroyProfileOnBrowserClose` remains enabled on macOS (confirmed not related)

🤖 Generated with [Claude Code](https://claude.com/claude-code)