### PR TITLE
Fix glic actor crash

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,3 +1,4 @@
+ungoogled-chromium/macos/fix-glic-actor-crash.patch
 ungoogled-chromium/macos/build-bindgen.patch
 ungoogled-chromium/macos/disable-clang-version-check.patch
 ungoogled-chromium/macos/disable-crashpad-handler.patch

--- a/patches/ungoogled-chromium/macos/fix-glic-actor-crash.patch
+++ b/patches/ungoogled-chromium/macos/fix-glic-actor-crash.patch
@@ -1,0 +1,36 @@
+# Disable Glic (Google AI Actor) for ungoogled-chromium builds
+#
+# kGlicActor is ENABLED_BY_DEFAULT on non-Android but requires Google-internal
+# services absent in ungoogled builds, causing two crashes:
+#
+# 1. BrowserView init: ActorTaskListBubbleController calls
+#    GlicActorTaskIconManagerFactory::GetForProfile -> GlicActorTaskIconManager(
+#    profile, actor_service=null) -> CHECK(actor_service) fires.
+#
+# 2. chrome://settings: AddGlicStrings -> ShouldShowWebActuationToggle accesses
+#    GlicKeyedService::actor_policy_checker() which is uninitialized when
+#    kGlicActor is disabled -> EXC_BAD_ACCESS at offset 0xac.
+
+--- a/chrome/common/chrome_features.cc
++++ b/chrome/common/chrome_features.cc
+@@ -264,7 +264,7 @@ BASE_FEATURE(kForcedAppRelaunchOnPlaceholderUpdate,
+ BASE_FEATURE(kGeoLanguage, base::FEATURE_DISABLED_BY_DEFAULT);
+
+ // Controls whether the actor component of Glic is enabled.
+-#if BUILDFLAG(IS_ANDROID)
++#if BUILDFLAG(IS_ANDROID) || !BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ BASE_FEATURE(kGlicActor, base::FEATURE_DISABLED_BY_DEFAULT);
+ #else
+ BASE_FEATURE(kGlicActor, base::FEATURE_ENABLED_BY_DEFAULT);
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -747,6 +747,9 @@ bool IsWebActuationDisabledForEnterprise(Profile* profile) {
+ }
+
+ bool ShouldShowWebActuationToggle(Profile* profile) {
++  if (!base::FeatureList::IsEnabled(features::kGlicActor)) {
++    return false;
++  }
+   auto* command_line = base::CommandLine::ForCurrentProcess();
+   if (command_line->HasSwitch(::switches::kGlicAlwaysShowWebActuationToggle)) {
+     return true;


### PR DESCRIPTION
Disable Glic (Google AI Actor) for ungoogled-chromium builds to prevent crashes caused by uninitialized or unavailable services during startup.

Remediates:
https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/325

Glic is a Google Chrome–specific feature and depends on services and infrastructure that are not present in ungoogled-chromium. Leaving it enabled results in invalid assumptions during initialization, leading to deterministic crashes.

This change disables Glic in ungoogled builds to align with the project’s removal of Google-specific functionality and ensure stable startup behavior.

Tested on macOS Tahoe 26.4.1. Scope is currently limited to macOS based on observed behavior in that environment.