### PR TITLE
Update to ungoogled-chromium 147.0.7727.116

### DIFF
--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -16,7 +16,7 @@ sudo du -hs "$_src_dir"
 rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -g "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -d -g "$_target_cpu"
 
 mkdir -p "$_src_dir/out/Default"
 
@@ -27,6 +27,6 @@ python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -p "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -d -p "$_target_cpu"
 
 rm -rvf "$_download_cache"


### PR DESCRIPTION
No modification aside from the submodule bump is needed.

Tarball download (instead of cloning) is used to work-around the depot_tools issue described in https://github.com/ungoogled-software/ungoogled-chromium/pull/3744.

This PR resolves #325.

---

Builds and runs fine locally.

<img width="710" height="192" alt="image" src="https://github.com/user-attachments/assets/7150b1a3-3961-440b-90ee-b646f8f82c49" />