### PR TITLE
Update to ungoogled-chromium 149.0.7827.53-1

### DIFF
--- a/downloads-arm64-rustlib.ini
+++ b/downloads-arm64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-arm64]
-version = 2026-02-27
+version = 2026-04-09
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = cd6b64563c73c4b482b557ab6715f513a1edde1fd05c33718d3bc0ab2361701b9329533
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2026-02-27
+version = 2026-04-09
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64-rustlib.ini
+++ b/downloads-x86-64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-x86-64]
-version = 2026-02-27
+version = 2026-04-09
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 3c1d16659764852555b0e23063e75c2fe64b7423d817093c5215a712ef6e16869279d78
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2026-02-27
+version = 2026-04-09
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/series
+++ b/patches/series
@@ -12,3 +12,4 @@ ungoogled-chromium/macos/bindgen-disable-static.patch
 ungoogled-chromium/macos/set-rustc-nightly-capability.patch
 ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
 ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
+ungoogled-chromium/macos/fix-nasm-build-config.patch

--- a/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
+++ b/patches/ungoogled-chromium/macos/bindgen-disable-static.patch
@@ -1,6 +1,6 @@
 --- a/tools/rust/build_bindgen.py
 +++ b/tools/rust/build_bindgen.py
-@@ -197,12 +197,11 @@ def main():
+@@ -204,12 +204,11 @@ def main():
      RunCargo([
          'clean',
      ] + cargo_shared_args)

--- a/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen-target-override.patch
@@ -1,6 +1,6 @@
 --- a/tools/rust/build_bindgen.py
 +++ b/tools/rust/build_bindgen.py
-@@ -166,6 +166,12 @@ def main():
+@@ -167,6 +167,12 @@ def main():
          '--skip-checkout',
          action='store_true',
          help='skip downloading the git repo. Useful for trying local changes')
@@ -13,7 +13,7 @@
      parser.add_argument('--skip-test',
                          action='store_true',
                          help='skip running tests')
-@@ -174,6 +180,7 @@ def main():
+@@ -175,6 +181,7 @@ def main():
      if not args.skip_checkout:
          CheckoutGitRepo("bindgen", BINDGEN_GIT_REPO, BINDGEN_GIT_VERSION,
                          BINDGEN_SRC_DIR)
@@ -21,7 +21,7 @@
  
      build_dir = BINDGEN_HOST_BUILD_DIR
      if os.path.exists(build_dir):
-@@ -193,7 +200,7 @@ def main():
+@@ -200,7 +207,7 @@ def main():
      static_feature = ",static" if ('windows' not in RustTargetTriple()) else ""
      cargo_args = [
          'build',
@@ -30,7 +30,7 @@
          f'--no-default-features',
          f'--features=logging' + static_feature,
          '--release',
-@@ -207,7 +214,7 @@ def main():
+@@ -214,7 +221,7 @@ def main():
  
      llvm_dir = os.path.join(THIRD_PARTY_DIR, 'llvm-build', 'Release+Asserts')
      shutil.copy(

--- a/patches/ungoogled-chromium/macos/build-bindgen.patch
+++ b/patches/ungoogled-chromium/macos/build-bindgen.patch
@@ -1,6 +1,6 @@
 --- a/tools/rust/build_bindgen.py
 +++ b/tools/rust/build_bindgen.py
-@@ -29,8 +29,7 @@ from update import (RmTree)
+@@ -30,8 +30,7 @@ from update import (RmTree)
  # The git hash to use.  See https://github.com/rust-lang/rust-bindgen/tags.
  # The current hash below corresponds to 0.72.1
  BINDGEN_GIT_VERSION = 'd874de8d646d9b8a3e7ba2db2bcd52f2fba8f1f5'
@@ -10,7 +10,7 @@
  
  BINDGEN_SRC_DIR = os.path.join(THIRD_PARTY_DIR, 'rust-toolchain-intermediate',
                                 'bindgen-src')
-@@ -96,15 +95,8 @@ def RunCargo(cargo_args):
+@@ -97,15 +96,8 @@ def RunCargo(cargo_args):
                f'the build_rust.py script builds rustc that is needed here.')
          sys.exit(1)
  
@@ -28,7 +28,7 @@
  
      env = collections.defaultdict(str, os.environ)
      # Cargo normally stores files in $HOME. Override this.
-@@ -213,7 +205,7 @@ def main():
+@@ -220,7 +212,7 @@ def main():
      install_dir = os.path.join(RUST_TOOLCHAIN_OUT_DIR)
      print(f'Installing bindgen to {install_dir} ...')
  

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1785,8 +1785,7 @@ config("compiler_deterministic") {
+@@ -1797,8 +1797,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,9 +2,9 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1236,7 +1236,7 @@ if (is_win) {
+@@ -1244,7 +1244,7 @@ if (is_win) {
  
-   # TOOD(crbug/1163903#c8) - thakis@ look into why profile and coverage
+   # TOOD(crbug.com/40740432#comment9) - thakis@ look into why profile and coverage
    # instrumentation adds these symbols in different orders
 -  if (!is_component_build && chrome_pgo_phase != 1 && !using_sanitizer) {
 +  if (false) {

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -1,6 +1,29 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -628,9 +628,6 @@ config("compiler") {
+@@ -533,9 +533,6 @@ config("compiler") {
+     # linker for Rust targets as well.
+     rustflags += [ "-Csplit-debuginfo=unpacked" ]
+ 
+-    # TODO(crbug.com/500431896): Figure out why constant literals breaks tests.
+-    cflags_objc = [ "-fno-objc-constant-literals" ]
+-    cflags_objcc = [ "-fno-objc-constant-literals" ]
+   }
+ 
+   # Linux/Android/Fuchsia common flags setup.
+@@ -588,12 +585,6 @@ config("compiler") {
+   if (is_clang) {
+     # Flags for diagnostics.
+     cflags += [ "-fcolor-diagnostics" ]
+-    if (!is_win) {
+-      cflags += [ "-fdiagnostics-show-inlining-chain" ]
+-    } else {
+-      # Combine after https://github.com/llvm/llvm-project/pull/192241
+-      cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+-    }
+     if (diagnostics_print_source_range_info && !is_win) {
+       cflags += [ "-fdiagnostics-print-source-range-info" ]
+     }
+@@ -627,9 +618,6 @@ config("compiler") {
      # The performance improvement does not seem worth the risk. See
      # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
      # for discussion.
@@ -10,35 +33,13 @@
  
      # TODO(hans): Remove this once Clang generates better optimized debug info
      # by default. https://crbug.com/765793
-@@ -1904,18 +1901,6 @@ config("sanitize_c_array_bounds") {
-     cflags = [
-       "-fsanitize=array-bounds",
-       "-fsanitize-trap=array-bounds",
--
--      # Some code users feature detection to determine if UBSAN (or any
--      # sanitizer) is enabled, they then do expensive debug like operations. We
--      # want to suppress this behaviour since we want to keep performance costs
--      # as low as possible while having these checks.
--      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
--
--      # Because we've enabled array-bounds sanitizing we also want to suppress
--      # the related warning about "unsafe-buffer-usage-in-static-sized-array",
--      # since we know that the array bounds sanitizing will catch any out-of-
--      # bounds accesses.
--      "-Wno-unsafe-buffer-usage-in-static-sized-array",
-     ]
-   }
- }
-@@ -1928,12 +1913,6 @@ config("sanitize_return") {
-     cflags = [
-       "-fsanitize=return",
-       "-fsanitize-trap=return",
--
--      # Some code users feature detection to determine if UBSAN (or any
--      # sanitizer) is enabled, they then do expensive debug like operations. We
--      # want to suppress this behaviour since we want to keep performance costs
--      # as low as possible while having these checks.
--      "-fsanitize-ignore-for-ubsan-feature=return",
-     ]
-   }
- }
+--- a/build/config/sanitizers/sanitizers.gni
++++ b/build/config/sanitizers/sanitizers.gni
+@@ -540,7 +540,6 @@ template("ubsan_hardening") {
+         # be usable even in release builds, i.e. as widely as possible.
+         # It's important not to have full-on UBSan workarounds activate
+         # just because we built support for a specific sanitizer.
+-        "-fsanitize-ignore-for-ubsan-feature=${invoker.sanitizer}",
+       ]
+       if (defined(invoker.cflags)) {
+         cflags += invoker.cflags

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -25,7 +25,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc1880nightlyd4f880f8c20250408"
++  rustc_version = "rustc1960nightly90048564220260408"
  
    # Whether artifacts produced by the Rust compiler can participate in ThinLTO.
    #

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -264,8 +264,6 @@ clang_lib("compiler_builtins") {
+@@ -267,8 +267,6 @@ clang_lib("compiler_builtins") {
      } else {
        assert(false, "unsupported target_platform=$target_platform")
      }
@@ -25,7 +25,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc1950nightly6a979b3e320260226"
++  rustc_version = "rustc1880nightlyd4f880f8c20250408"
  
    # Whether artifacts produced by the Rust compiler can participate in ThinLTO.
    #

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,10 +2,10 @@
 
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
-@@ -1172,10 +1172,6 @@ static_library("browser") {
-     "//chrome/browser/profiles:profile_util_impl",
-     "//chrome/browser/profiles:profile_manager",
-     "//chrome/browser/profiles:profile_manager_impl",
+@@ -421,10 +421,6 @@ static_library("browser") {
+     # c/b/metrics/process_memory_metrics_emitter.h is componentized.
+     "//chrome/browser/resource_coordinator:impl",
+ 
 -    "//chrome/browser/safe_browsing",
 -    "//chrome/browser/safe_browsing:advanced_protection",
 -    "//chrome/browser/safe_browsing:metrics_collector",
@@ -13,9 +13,9 @@
      "//chrome/browser/search",
      "//chrome/browser/search_engine_choice:impl",
      "//chrome/browser/signin:impl",
-@@ -1642,7 +1638,6 @@ static_library("browser") {
-     "//chrome/browser/renderer_context_menu:impl",
-     "//chrome/browser/renderer_host",
+@@ -932,7 +928,6 @@ static_library("browser") {
+     "//chrome/browser/resource_coordinator:impl",
+     "//chrome/browser/resource_coordinator:utils",
      "//chrome/browser/resources/accessibility:resources",
 -    "//chrome/browser/safe_browsing",
      "//chrome/browser/safe_browsing:advanced_protection",
@@ -23,7 +23,7 @@
      "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -830,9 +830,6 @@ source_set("extensions") {
+@@ -846,9 +846,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -33,7 +33,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -865,7 +862,6 @@ source_set("extensions") {
+@@ -881,7 +878,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -43,7 +43,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -586,18 +586,8 @@ static_library("ui") {
+@@ -629,18 +629,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -62,7 +62,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5614,7 +5604,6 @@ group("ui_public_dependencies") {
+@@ -5704,7 +5694,6 @@ group("ui_public_dependencies") {
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -85,7 +85,7 @@
        "obfuscated_archive_analysis_delegate.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2393,15 +2393,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2406,15 +2406,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -103,8 +103,8 @@
      ash::prefs::kAuthenticationFlowAutoReloadInterval,
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7853,8 +7853,6 @@ test("unit_tests") {
-       "//chrome/browser/apps/app_shim",
+@@ -7898,8 +7898,6 @@ test("unit_tests") {
+       "//chrome/browser/mac:unit_tests",
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/common/notifications",
 -      "//chrome/common/safe_browsing:archive_analyzer_results",
@@ -114,7 +114,7 @@
        "//chrome/utility/safe_browsing",
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8131,33 +8131,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8269,33 +8269,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -11,7 +11,7 @@
      file_match = dsymutil_file_re.search(line)
 --- a/build/toolchain/apple/toolchain.gni
 +++ b/build/toolchain/apple/toolchain.gni
-@@ -233,8 +233,9 @@ template("single_apple_toolchain") {
+@@ -234,8 +234,9 @@ template("single_apple_toolchain") {
      if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
        dsym_switch += "-Wcrl,dsymutilpath," +

--- a/patches/ungoogled-chromium/macos/fix-nasm-build-config.patch
+++ b/patches/ungoogled-chromium/macos/fix-nasm-build-config.patch
@@ -1,0 +1,12 @@
+--- a/third_party/nasm/config/config-mac.h
++++ b/third_party/nasm/config/config-mac.h
+@@ -219,9 +219,6 @@
+    */
+ #define HAVE_DECL_STRSEP 1
+ 
+-/* Define to 1 if you have the <endian.h> header file. */
+-#define HAVE_ENDIAN_H 1
+-
+ /* Define to 1 if you have the 'faccessat' function. */
+ #define HAVE_FACCESSAT 1
+ 

--- a/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
+++ b/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
@@ -35,7 +35,7 @@
  #
 --- a/v8/gni/v8.gni
 +++ b/v8/gni/v8.gni
-@@ -392,6 +392,7 @@ v8_add_configs = [
+@@ -391,6 +391,7 @@ v8_add_configs = [
    v8_path_prefix + ":features",
    v8_path_prefix + ":toolchain",
    v8_path_prefix + ":strict_warnings",


### PR DESCRIPTION
- Update submodule to ungoogled-chromium 149.0.7827.53-1
- Update rust to 2026-04-09
- Update mac-specific patches

Some changes were needed for a successful build:
- `-fno-objc-constant-literals` and `-fdiagnostics-show-inlining-chain` are not supported by our clang build
- the `third_party/nasm` submodule is (erroneously?) configured via `third_party/nasm/config/config-mac.h` to build using the macro `HAVE_ENDIAN_H` when it should only set `HAVE_MACHINE_ENDIAN_H`

Builds and runs fine on my x86_64 machine.
