### PR TITLE
Update to ungoogled-chromium 149.0.7827.102-1

### DIFF
--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -1,26 +1,5 @@
 # Fix GN safe_browsing and building with safebrowsing disabled on macOS
 
---- a/chrome/browser/BUILD.gn
-+++ b/chrome/browser/BUILD.gn
-@@ -421,10 +421,6 @@ static_library("browser") {
-     # c/b/metrics/process_memory_metrics_emitter.h is componentized.
-     "//chrome/browser/resource_coordinator:impl",
- 
--    "//chrome/browser/safe_browsing",
--    "//chrome/browser/safe_browsing:advanced_protection",
--    "//chrome/browser/safe_browsing:metrics_collector",
--    "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
-     "//chrome/browser/search",
-     "//chrome/browser/search_engine_choice:impl",
-     "//chrome/browser/signin:impl",
-@@ -932,7 +928,6 @@ static_library("browser") {
-     "//chrome/browser/resource_coordinator:impl",
-     "//chrome/browser/resource_coordinator:utils",
-     "//chrome/browser/resources/accessibility:resources",
--    "//chrome/browser/safe_browsing",
-     "//chrome/browser/safe_browsing:advanced_protection",
-     "//chrome/browser/safe_browsing:metrics_collector",
-     "//chrome/browser/safe_browsing:verdict_cache_manager_factory",
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
 @@ -846,9 +846,6 @@ source_set("extensions") {

--- a/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
+++ b/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
@@ -35,7 +35,7 @@
  #
 --- a/v8/gni/v8.gni
 +++ b/v8/gni/v8.gni
-@@ -391,6 +391,7 @@ v8_add_configs = [
+@@ -393,6 +393,7 @@ v8_add_configs = [
    v8_path_prefix + ":features",
    v8_path_prefix + ":toolchain",
    v8_path_prefix + ":strict_warnings",


### PR DESCRIPTION
No major changes needed. Delete some removals from fix-disabling-safebrowsing.patch because they're [now](https://github.com/ungoogled-software/ungoogled-chromium/pull/3817) part of the upstream patchset.

Builds an runs fine on my x86_64 machine (I built the upstream pull request before it got merged...).