### PR TITLE
Update to ungoogled-chromium 151.0.7922.71

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,7 @@ _root_dir="$(dirname "$(greadlink -f "$0")")"
 _download_cache="$_root_dir/build/download_cache"
 _src_dir="$_root_dir/build/src"
 _main_repo="$_root_dir/ungoogled-chromium"
+_cipd="$_src_dir/third_party/depot_tools/cipd"
 
 # Clone to get the Chromium Source
 clone=true
@@ -57,6 +58,26 @@ mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
 "$_root_dir/retrieve_and_unpack_resource.sh" -p $_arch
+
+# Dawn's Tint source generator uses a DEPS-pinned Go toolchain. It is not part
+# of the downloadable source archive and must be restored after binary pruning.
+case "$(uname -m)" in
+  arm64)
+    _dawn_go_platform="mac-arm64"
+    ;;
+  x86_64)
+    _dawn_go_platform="mac-amd64"
+    ;;
+  *)
+    echo "Unsupported macOS host architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+printf 'infra/3pp/tools/go/%s version:3@1.25.0\n' "$_dawn_go_platform" |
+  "$_cipd" ensure \
+    -cache-dir "$_download_cache/cipd" \
+    -root "$_src_dir/third_party/dawn/tools/golang/$_dawn_go_platform" \
+    -ensure-file -
 
 cd "$_src_dir"
 

--- a/downloads-arm64-rustlib.ini
+++ b/downloads-arm64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-arm64]
-version = 2026-04-09
+version = 2026-06-16
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-arm64.ini
+++ b/downloads-arm64.ini
@@ -18,7 +18,7 @@ sha512 = cd6b64563c73c4b482b557ab6715f513a1edde1fd05c33718d3bc0ab2361701b9329533
 output_path = third_party/node/mac_arm64/node-darwin-arm64
 
 [rust]
-version = 2026-04-09
+version = 2026-06-16
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-aarch64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-aarch64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/downloads-x86-64-rustlib.ini
+++ b/downloads-x86-64-rustlib.ini
@@ -1,5 +1,5 @@
 [rustlib-x86-64]
-version = 2026-04-09
+version = 2026-06-16
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain/rustc/lib/rustlib

--- a/downloads-x86-64.ini
+++ b/downloads-x86-64.ini
@@ -18,7 +18,7 @@ sha512 = 3c1d16659764852555b0e23063e75c2fe64b7423d817093c5215a712ef6e16869279d78
 output_path = third_party/node/mac/node-darwin-x64
 
 [rust]
-version = 2026-04-09
+version = 2026-06-16
 url = https://static.rust-lang.org/dist/%(version)s/rust-nightly-x86_64-apple-darwin.tar.xz
 download_filename = rust-nightly-%(version)s-x86_64-apple-darwin.tar.xz
 output_path = third_party/rust-toolchain

--- a/patches/series
+++ b/patches/series
@@ -13,3 +13,4 @@ ungoogled-chromium/macos/set-rustc-nightly-capability.patch
 ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
 ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
 ungoogled-chromium/macos/fix-nasm-build-config.patch
+ungoogled-chromium/macos/fix-anyappleos-availability.patch

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1458,8 +1458,7 @@ config("compiler_deterministic") {
+@@ -1464,8 +1464,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1253,7 +1253,7 @@ if (is_win) {
+@@ -1256,7 +1256,7 @@ if (is_win) {
  
    # TOOD(crbug.com/40740432#comment9) - thakis@ look into why profile and
    # coverage instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -1,19 +1,21 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -576,12 +576,6 @@ config("compiler") {
+@@ -576,14 +576,6 @@ config("compiler") {
    if (is_clang) {
      # Flags for diagnostics.
      cflags += [ "-fcolor-diagnostics" ]
--    if (!is_win) {
--      cflags += [ "-fdiagnostics-show-inlining-chain" ]
--    } else {
--      # Combine after https://github.com/llvm/llvm-project/pull/192241
--      cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+-    if (!is_wasm) {
+-      if (!is_win) {
+-        cflags += [ "-fdiagnostics-show-inlining-chain" ]
+-      } else {
+-        # Combine after https://github.com/llvm/llvm-project/pull/192241
+-        cflags += [ "/clang:-fdiagnostics-show-inlining-chain" ]
+-      }
 -    }
      if (diagnostics_print_source_range_info && !is_win) {
        cflags += [ "-fdiagnostics-print-source-range-info" ]
      }
-@@ -615,9 +609,6 @@ config("compiler") {
+@@ -617,9 +609,6 @@ config("compiler") {
      # The performance improvement does not seem worth the risk. See
      # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
      # for discussion.
@@ -25,7 +27,7 @@
      # by default. https://crbug.com/765793
 --- a/build/config/sanitizers/sanitizers.gni
 +++ b/build/config/sanitizers/sanitizers.gni
-@@ -541,7 +541,6 @@ template("ubsan_hardening") {
+@@ -540,7 +540,6 @@ template("ubsan_hardening") {
          # be usable even in release builds, i.e. as widely as possible.
          # It's important not to have full-on UBSan workarounds activate
          # just because we built support for a specific sanitizer.

--- a/patches/ungoogled-chromium/macos/fix-anyappleos-availability.patch
+++ b/patches/ungoogled-chromium/macos/fix-anyappleos-availability.patch
@@ -1,0 +1,23 @@
+--- a/net/base/apple/url_conversions.mm
++++ b/net/base/apple/url_conversions.mm
+@@ -59,6 +59,7 @@ GURL GURLWithNSURL(NSURL* url) {
+   // TODO(crbug.com/523200130): Remove this workaround when the minimum
+   // deployment target is iOS 27.0 or higher.
+-  if (!@available(anyAppleOS 27.0, *)) {
++  if (!@available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0,
++                   *)) {
+     if (base::FeatureList::IsEnabled(
+             features::kUseNSURLDataForGURLConversion)) {
+       // The bug in NSURL absoluteString is natively fixed in iOS 27+.
+--- a/net/base/apple/url_conversions_unittest.mm
++++ b/net/base/apple/url_conversions_unittest.mm
+@@ -255,7 +255,8 @@ TEST_F(URLConversionTest, TestGURLWithNSURLFeatureDisabled) {
+   NSURL* url = [NSURL URLWithString:@"about:blank#hash"];
+   GURL gurl = GURLWithNSURL(url);
+ 
+-  if (@available(anyAppleOS 27.0, *)) {
++  if (@available(macOS 27.0, iOS 27.0, tvOS 27.0, watchOS 27.0,
++                   *)) {
+     // If this test fails, it means Apple has broken the bug fix in iOS 27+.
+     EXPECT_EQ("about:blank#hash", gurl.spec());
+   } else {

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -13,7 +13,7 @@
 +++ b/build/config/rust.gni
 @@ -57,7 +57,7 @@ declare_args() {
    # using a *nightly* version of Rust toolchain (see
-   # `tools/rust/unstable_rust_feature_usage.md`) although other projects (e.g.
+   # `docs/rust/unstable_rust_feature_usage.md`) although other projects (e.g.
    # V8) may be compatible with the stable version of Rust toolchain.
 -  rust_sysroot_absolute = ""
 +  rust_sysroot_absolute = "//third_party/rust-toolchain"

--- a/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-with-rust.patch
@@ -25,7 +25,7 @@
    # Rust targets to be rebuilt, which allows you to update your toolchain and
    # not break incremental builds.
 -  rustc_version = ""
-+  rustc_version = "rustc1960nightly90048564220260408"
++  rustc_version = "rustc1980nightly01dfd792420260615"
  
    # Whether artifacts produced by the Rust compiler can participate in ThinLTO.
    #

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -868,9 +868,6 @@ source_set("extensions") {
+@@ -870,9 +870,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -12,7 +12,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -903,7 +900,6 @@ source_set("extensions") {
+@@ -904,7 +901,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -22,7 +22,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -564,18 +564,8 @@ static_library("ui") {
+@@ -847,18 +847,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -41,7 +41,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5416,7 +5406,6 @@ group("ui_public_dependencies") {
+@@ -5607,7 +5597,6 @@ group("ui_public_dependencies") {
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -64,25 +64,32 @@
        "obfuscated_archive_analysis_delegate.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2437,15 +2437,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2454,22 +2454,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
+-// The per-user policy is available on ChromeOS (declared `future_on:
+-// chrome_os`), but the per-browser policy is not (it is `chrome.*`, i.e.
+-// win/mac/linux only). As a result the per-browser `key::` constant is only
+-// generated in non-ChromeOS builds, so its entry must be guarded accordingly.
 -#if BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
 -  { key::kProvisionManagedClientCertificateForUser,
 -    client_certificates::prefs::kProvisionManagedClientCertificateForUserPrefs,
 -    base::Value::Type::INTEGER },
+-#endif  // BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
+-
+-#if BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES) && !BUILDFLAG(IS_CHROMEOS)
 -  { key::kProvisionManagedClientCertificateForBrowser,
 -    client_certificates::prefs::kProvisionManagedClientCertificateForBrowserPrefs,
 -    base::Value::Type::INTEGER },
--#endif  // BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES)
+-#endif  // BUILDFLAG(ENTERPRISE_CLIENT_CERTIFICATES) && !BUILDFLAG(IS_CHROMEOS)
 -
  #if BUILDFLAG(IS_CHROMEOS)
    { key::kDeviceAuthenticationFlowAutoReloadInterval,
      ash::prefs::kAuthenticationFlowAutoReloadInterval,
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -8038,8 +8038,6 @@ test("unit_tests") {
+@@ -6737,8 +6737,6 @@ test("unit_tests") {
        "//chrome/browser/mac:unit_tests",
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/common/notifications",
@@ -93,7 +100,7 @@
        "//chrome/utility/safe_browsing",
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8363,33 +8363,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8424,33 +8424,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/fix-dsymutil.patch
+++ b/patches/ungoogled-chromium/macos/fix-dsymutil.patch
@@ -11,7 +11,7 @@
      file_match = dsymutil_file_re.search(line)
 --- a/build/toolchain/apple/toolchain.gni
 +++ b/build/toolchain/apple/toolchain.gni
-@@ -252,8 +252,9 @@ template("single_apple_toolchain") {
+@@ -236,8 +236,9 @@ template("single_apple_toolchain") {
      if (_enable_dsyms) {
        dsym_switch = " -Wcrl,dsym,{{root_out_dir}} "
        dsym_switch += "-Wcrl,dsymutilpath," +

--- a/patches/ungoogled-chromium/macos/no-unknown-warnings.patch
+++ b/patches/ungoogled-chromium/macos/no-unknown-warnings.patch
@@ -1,6 +1,6 @@
 --- a/build/config/mac/BUILD.gn
 +++ b/build/config/mac/BUILD.gn
-@@ -50,6 +50,8 @@ config("compiler") {
+@@ -43,6 +43,8 @@ config("compiler") {
    if (export_libcxxabi_from_executables) {
      ldflags += [ "-Wl,-undefined,dynamic_lookup" ]
    }

--- a/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
+++ b/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
@@ -1,6 +1,6 @@
 --- a/v8/BUILD.gn
 +++ b/v8/BUILD.gn
-@@ -1929,6 +1929,32 @@ config("always_turbofanimize") {
+@@ -1947,6 +1947,32 @@ config("always_turbofanimize") {
    }
  }
  
@@ -35,7 +35,7 @@
  #
 --- a/v8/gni/v8.gni
 +++ b/v8/gni/v8.gni
-@@ -395,6 +395,7 @@ v8_add_configs = [
+@@ -405,6 +405,7 @@ v8_add_configs = [
    v8_path_prefix + ":features",
    v8_path_prefix + ":toolchain",
    v8_path_prefix + ":strict_warnings",


### PR DESCRIPTION
Notes:

- Submodule is bumped.
- Patches are refreshed.
- Rust is updated.
- Apple compatible check it fixed to a older format.
- Go Toolchain is fixed.

---

Builds and runs fine locally.

<img width="714" height="193" alt="image" src="https://github.com/user-attachments/assets/146c605a-ecd2-4e7c-9184-35e1f78edec2" />