### PR TITLE
Enable PGO and Thin LTO Optimizations & Use Cloning in CI

### DIFF
--- a/.github/scripts/github_fetch_resources.sh
+++ b/.github/scripts/github_fetch_resources.sh
@@ -16,7 +16,7 @@ sudo du -hs "$_src_dir"
 rm -rf "$_src_dir/out" || true
 mkdir -p "$_download_cache"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -d -g "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -g "$_target_cpu"
 
 mkdir -p "$_src_dir/out/Default"
 
@@ -27,6 +27,6 @@ python3 "$_main_repo/utils/domain_substitution.py" apply -r "$_main_repo/domain_
 mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
-"$_root_dir/retrieve_and_unpack_resource.sh" -d -p "$_target_cpu"
+"$_root_dir/retrieve_and_unpack_resource.sh" -p "$_target_cpu"
 
 rm -rvf "$_download_cache"

--- a/flags.macos.gn
+++ b/flags.macos.gn
@@ -1,4 +1,5 @@
 blink_symbol_level=0
+chrome_pgo_phase=2
 enable_iterator_debugging=false
 enable_mse_mpeg2ts_stream_parser=true
 enable_rust=true
@@ -11,4 +12,5 @@ is_debug=false
 is_official_build=true
 proprietary_codecs=true
 symbol_level=1
+use_thin_lto=true
 use_sysroot=false


### PR DESCRIPTION
This PR:

- Enable Compiler Optimizations for Better Performance (https://github.com/ungoogled-software/ungoogled-chromium/issues/3892)
- Build with cloned resources as work-around of `histograms_xml` issue (https://github.com/ungoogled-software/ungoogled-chromium/pull/3883 build note 2)