### PR TITLE
Update to ungoogled-chromium 151.0.7922.173

### DIFF
--- a/.github/scripts/github_setup_env_toolchain.sh
+++ b/.github/scripts/github_setup_env_toolchain.sh
@@ -2,7 +2,7 @@
 
 # Simple script for setting up all toolchain dependencies for building Ungoogled-Chromium on macOS
 
-brew install ninja coreutils --overwrite
+brew install go ninja coreutils --overwrite
 
 # Install PySocks and httplib2 for Python from PyPI
 pip3 install PySocks httplib2 --break-system-packages

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,6 @@ _root_dir="$(dirname "$(greadlink -f "$0")")"
 _download_cache="$_root_dir/build/download_cache"
 _src_dir="$_root_dir/build/src"
 _main_repo="$_root_dir/ungoogled-chromium"
-_cipd="$_src_dir/third_party/depot_tools/cipd"
 
 # Clone to get the Chromium Source
 clone=true
@@ -58,26 +57,6 @@ mkdir -p "$_src_dir/third_party/llvm-build/Release+Asserts"
 mkdir -p "$_src_dir/third_party/rust-toolchain/bin"
 
 "$_root_dir/retrieve_and_unpack_resource.sh" -p $_arch
-
-# Dawn's Tint source generator uses a DEPS-pinned Go toolchain. It is not part
-# of the downloadable source archive and must be restored after binary pruning.
-case "$(uname -m)" in
-  arm64)
-    _dawn_go_platform="mac-arm64"
-    ;;
-  x86_64)
-    _dawn_go_platform="mac-amd64"
-    ;;
-  *)
-    echo "Unsupported macOS host architecture: $(uname -m)" >&2
-    exit 1
-    ;;
-esac
-printf 'infra/3pp/tools/go/%s version:3@1.25.0\n' "$_dawn_go_platform" |
-  "$_cipd" ensure \
-    -cache-dir "$_download_cache/cipd" \
-    -root "$_src_dir/third_party/dawn/tools/golang/$_dawn_go_platform" \
-    -ensure-file -
 
 cd "$_src_dir"
 

--- a/retrieve_and_unpack_resource.sh
+++ b/retrieve_and_unpack_resource.sh
@@ -105,4 +105,25 @@ if $retrieve_arch_specific; then
     _llvm_bin_dir="$_llvm_dir/bin"
 
     ln -s "$_llvm_bin_dir/llvm-install-name-tool" "$_llvm_bin_dir/install_name_tool"
+
+    # Dawn invokes Go from its DEPS toolchain path when generating Tint sources.
+    # Match the system-tooling setup used by other distributions after pruning
+    # the bundled toolchain.
+    case "$(uname -m)" in
+        arm64)
+            _dawn_go_platform="mac-arm64"
+            ;;
+        x86_64)
+            _dawn_go_platform="mac-amd64"
+            ;;
+        *)
+            echo "Unsupported macOS host architecture: $(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+
+    _go_binary="$(command -v go)"
+    _dawn_go_bin_dir="$_src_dir/third_party/dawn/tools/golang/$_dawn_go_platform/bin"
+    mkdir -p "$_dawn_go_bin_dir"
+    ln -sfn "$_go_binary" "$_dawn_go_bin_dir/go"
 fi


### PR DESCRIPTION
No modification aside from the submodule bump is needed.

Go toolchain is fixed.

---

Builds and runs fine locally.