### PR TITLE
Update to ungoogled-chromium 152.0.7977.64

### DIFF
--- a/.github/scripts/github_prepare_artifacts.sh
+++ b/.github/scripts/github_prepare_artifacts.sh
@@ -1,5 +1,7 @@
-#!/bin/bash -eux
+#!/bin/bash
 # Simple script for packing Ungoogled-Chromium macOS build artifacts on GitHub Actions
+
+set -euo pipefail
 
 _target_cpu="${1:-x86_64}"
 
@@ -9,19 +11,17 @@ _src_dir="$_root_dir/build/src"
 # If build finished successfully
 if [[ -f "$_root_dir/build_finished_$_target_cpu.log" ]] ; then
   # For packaging
-  _chromium_version=$(cat $_root_dir/ungoogled-chromium/chromium_version.txt)
-  _ungoogled_revision=$(cat $_root_dir/ungoogled-chromium/revision.txt)
-  _package_revision=$(cat $_root_dir/revision.txt)
+  _chromium_version="$(cat "$_root_dir/ungoogled-chromium/chromium_version.txt")"
+  _ungoogled_revision="$(cat "$_root_dir/ungoogled-chromium/revision.txt")"
+  _package_revision="$(cat "$_root_dir/revision.txt")"
 
   _file_name="ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_${_target_cpu}-macos.dmg"
   _hash_name="${_file_name}.hashes.md"
 
   cd "$_src_dir"
 
-  xattr -cs out/Default/Chromium.app
-
-  # Prepar the certificate for app signing
-  echo $MACOS_CERTIFICATE | base64 --decode > "$TMPDIR/certificate.p12"
+  # Prepare the certificate for app signing
+  printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > "$TMPDIR/certificate.p12"
 
   security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" build.keychain
   security default-keychain -s build.keychain
@@ -29,39 +29,8 @@ if [[ -f "$_root_dir/build_finished_$_target_cpu.log" ]] ; then
   security import "$TMPDIR/certificate.p12" -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
   security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
 
-  # Sign the binary
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier chrome_crashpad_handler --options=restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/chrome_crashpad_handler
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper.app
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper.renderer --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-renderer-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Renderer\).app
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-gpu-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(GPU\).app
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework.AlertNotificationService --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Alerts\).app
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier app_mode_loader --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/app_mode_loader
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier web_app_shortcut_copier --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/web_app_shortcut_copier
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libEGL out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libEGL.dylib
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libGLESv2 out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libGLESv2.dylib
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libvk_swiftshader out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libvk_swiftshader.dylib
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework
-  codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements $_root_dir/entitlements/app-entitlements.plist --requirements '=designated => identifier "io.ungoogled-software.ungoogled-chromium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */' out/Default/Chromium.app
-
-  # Verify the binary signature
-  codesign --verify --deep --verbose=4 out/Default/Chromium.app
-
-  # Pepare app notarization
-  ditto -c -k --keepParent "out/Default/Chromium.app" "$TMPDIR/notarize.zip"
-
-  # Notarize the app
-  xcrun notarytool submit "$TMPDIR/notarize.zip" --wait \
-    --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" \
-    --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" \
-    --password "$PROD_MACOS_NOTARIZATION_PWD"
-  xcrun stapler staple "out/Default/Chromium.app"
-
-  # Package the app
-  chrome/installer/mac/pkg-dmg \
-    --sourcefile --source out/Default/Chromium.app \
-    --target "$_root_dir/$_file_name" \
-    --volname Chromium --symlink /Applications:/Applications \
-    --format UDBZ --verbosity 2
+  # Sign, notarize, staple, and package using the same path as local builds.
+  "$_root_dir/sign_and_package_app.sh" "$_root_dir/$_file_name"
 
   cd "$_root_dir"
   echo -e "md5: \nsha1: \nsha256: " | tee ./hash_types.txt
@@ -69,9 +38,7 @@ if [[ -f "$_root_dir/build_finished_$_target_cpu.log" ]] ; then
 
   _hash_md=$(paste ./hash_types.txt ./sums.txt | awk '{print $1 " " $2}')
 
-  echo "file_name=$_file_name" >> $GITHUB_OUTPUT
-
-  _gh_run_href="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+  printf 'file_name=%s\n' "$_file_name" >> "$GITHUB_OUTPUT"
 
   printf '[Hashes](https://en.wikipedia.org/wiki/Cryptographic_hash_function) for the disk image `%s`: \n' "$_file_name" | tee -a ./${_hash_name}
   printf '\n```\n%s\n```\n' "$_hash_md" | tee -a ./${_hash_name}

--- a/.github/scripts/github_prepare_artifacts.sh
+++ b/.github/scripts/github_prepare_artifacts.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 
 _target_cpu="${1:-x86_64}"
 
-_root_dir="$(dirname "$(greadlink -f "$0")")"
+_script_dir="$(dirname "$(greadlink -f "$0")")"
+_root_dir="$(greadlink -f "$_script_dir/../..")"
 _src_dir="$_root_dir/build/src"
 
 # If build finished successfully

--- a/README.md
+++ b/README.md
@@ -92,43 +92,6 @@ If you want to notarize the build, you need to have an Apple Developer ID and a 
 - `PROD_MACOS_NOTARIZATION_TEAM_ID`: Your Apple Developer Team ID, which can be found in the Apple Developer membership page
 - `PROD_MACOS_NOTARIZATION_PWD`: An app-specific password generated in the Apple ID account settings
 
-If you don't have an Apple Developer ID to sign the build (or you don't want to sign it), you can comment the following parts in `sign_and_package_app.sh`:
-
-```sh
-# Sign the binary
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier chrome_crashpad_handler --options=restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/chrome_crashpad_handler
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper.app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper.renderer --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-renderer-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Renderer\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-gpu-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(GPU\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework.AlertNotificationService --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Alerts\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier app_mode_loader --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/app_mode_loader
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier web_app_shortcut_copier --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/web_app_shortcut_copier
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libEGL out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libEGL.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libGLESv2 out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libGLESv2.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libvk_swiftshader out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libvk_swiftshader.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements $_root_dir/entitlements/app-entitlements.plist --requirements '=designated => identifier "io.ungoogled-software.ungoogled-chromium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */' out/Default/Chromium.app
-
-# Verify the binary signature
-codesign --verify --deep --verbose=4 out/Default/Chromium.app
-
-# Pepare app notarization
-ditto -c -k --keepParent "out/Default/Chromium.app" "notarize.zip"
-
-# Notarize the app
-xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
-xcrun notarytool submit "notarize.zip" --keychain-profile "notarytool-profile" --wait
-xcrun stapler staple "out/Default/Chromium.app"
-```
-
-and uncomment the following part:
-
-```sh
-# codesign --force --deep --sign - out/Default/Chromium.app
-```
-
-to use ad-hoc signing.
-
 Then, run the following:
 
 ```sh
@@ -151,6 +114,14 @@ or, if you want to build for x86_64 on an Apple Silicon Mac:
 ```sh
 ./build.sh x86_64
 ```
+
+If you don't have an Apple Developer ID, you can create an ad-hoc signed build by setting `MACOS_AD_HOC_SIGNING=1`:
+
+```sh
+MACOS_AD_HOC_SIGNING=1 ./build.sh
+```
+
+The resulting build is not notarized. The same environment variable can be used with `./build.sh x86_64`.
 
 Once it's complete, a `.dmg` should appear in `build/`.
 

--- a/README.md
+++ b/README.md
@@ -125,10 +125,26 @@ The resulting build is not notarized. The same environment variable can be used 
 
 Once it's complete, a `.dmg` should appear in `build/`.
 
+If compilation completed and only signing, notarization, or DMG creation failed,
+restart packaging from the repository root without rebuilding Chromium:
+
+```sh
+./sign_and_package_app.sh
+```
+
+For an ad-hoc signed package, use:
+
+```sh
+MACOS_AD_HOC_SIGNING=1 ./sign_and_package_app.sh
+```
+
+The regular signing and notarization environment variables listed above must
+still be set when creating a notarized package.
+
 **NOTE**: If the build fails, you must take additional steps before re-running the build:
 
 * If the build fails while downloading the Chromium source code, it can be fixed by removing `build/downloads_cache` and re-running the build instructions.
-* If the build fails at any other point after downloading, it can be fixed by removing `build/src` and re-running the build instructions.
+* If the build fails during source preparation or compilation, it can be fixed by removing `build/src` and re-running the build instructions.
 
 ## Developer info
 

--- a/build.sh
+++ b/build.sh
@@ -67,4 +67,4 @@ cd "$_src_dir"
 
 ninja -C out/Default chrome chromedriver
 
-"$_root_dir/sign_and_package_app.sh"
+CHROMIUM_SRC_DIR="$_src_dir" "$_root_dir/sign_and_package_app.sh"

--- a/patches/series
+++ b/patches/series
@@ -14,3 +14,4 @@ ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
 ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
 ungoogled-chromium/macos/fix-nasm-build-config.patch
 ungoogled-chromium/macos/fix-anyappleos-availability.patch
+ungoogled-chromium/macos/fix-build-without-crubit.patch

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -22,7 +22,7 @@
 -    # TODO(crbug.com/534655507): Remove in the next Clang roll.
 -    clang_version = "23"
 -  }
-+  clang_version = "23"
++  clang_version = "22"
  }
  
  # Extension for shared library files (including leading dot).

--- a/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
+++ b/patches/ungoogled-chromium/macos/disable-clang-version-check.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -1464,8 +1464,7 @@ config("compiler_deterministic") {
+@@ -1466,8 +1466,7 @@ config("compiler_deterministic") {
  }
  
  config("clang_revision") {
@@ -12,12 +12,17 @@
        _head_revision_stamp_path = "//third_party/llvm-build/force_head_revision"
 --- a/build/toolchain/toolchain.gni
 +++ b/build/toolchain/toolchain.gni
-@@ -41,7 +41,7 @@ declare_args() {
+@@ -41,12 +41,7 @@ declare_args() {
  }
  
  declare_args() {
--  clang_version = "23"
-+  clang_version = "22"
+-  if (llvm_force_head_revision) {
+-    clang_version = "24"
+-  } else {
+-    # TODO(crbug.com/534655507): Remove in the next Clang roll.
+-    clang_version = "23"
+-  }
++  clang_version = "23"
  }
  
  # Extension for shared library files (including leading dot).

--- a/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
+++ b/patches/ungoogled-chromium/macos/disable-symbol-order-verification.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/BUILD.gn
 +++ b/chrome/BUILD.gn
-@@ -1256,7 +1256,7 @@ if (is_win) {
+@@ -1303,7 +1303,7 @@ if (is_win) {
  
    # TOOD(crbug.com/40740432#comment9) - thakis@ look into why profile and
    # coverage instrumentation adds these symbols in different orders

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -1,6 +1,6 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -576,14 +576,6 @@ config("compiler") {
+@@ -578,14 +578,6 @@ config("compiler") {
    if (is_clang) {
      # Flags for diagnostics.
      cflags += [ "-fcolor-diagnostics" ]
@@ -15,7 +15,7 @@
      if (diagnostics_print_source_range_info && !is_win) {
        cflags += [ "-fdiagnostics-print-source-range-info" ]
      }
-@@ -617,9 +609,6 @@ config("compiler") {
+@@ -619,9 +611,6 @@ config("compiler") {
      # The performance improvement does not seem worth the risk. See
      # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
      # for discussion.
@@ -27,7 +27,7 @@
      # by default. https://crbug.com/765793
 --- a/build/config/sanitizers/sanitizers.gni
 +++ b/build/config/sanitizers/sanitizers.gni
-@@ -540,7 +540,6 @@ template("ubsan_hardening") {
+@@ -542,7 +542,6 @@ template("ubsan_hardening") {
          # be usable even in release builds, i.e. as widely as possible.
          # It's important not to have full-on UBSan workarounds activate
          # just because we built support for a specific sanitizer.

--- a/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
+++ b/patches/ungoogled-chromium/macos/disable-unsupported-llvm-flags.patch
@@ -35,3 +35,14 @@
        ]
        if (defined(invoker.cflags)) {
          cflags += invoker.cflags
+--- a/third_party/dawn/src/utils/BUILD.gn
++++ b/third_party/dawn/src/utils/BUILD.gn
+@@ -218,8 +218,6 @@ config("dawn_warnings") {
+       # the analysis pass.
+       "-Wno-lifetime-safety",
+       "-Wno-lifetime-safety-all",
+-      "-Xclang=-fno-lifetime-safety-inference",
+-      "-Xclang=-fno-experimental-lifetime-safety-tu-analysis",
+     ]
+ 
+     # P3. Checks that could be nice but probably don't help with hardening.

--- a/patches/ungoogled-chromium/macos/fix-anyappleos-availability.patch
+++ b/patches/ungoogled-chromium/macos/fix-anyappleos-availability.patch
@@ -1,6 +1,7 @@
 --- a/net/base/apple/url_conversions.mm
 +++ b/net/base/apple/url_conversions.mm
-@@ -59,6 +59,7 @@ GURL GURLWithNSURL(NSURL* url) {
+@@ -58,7 +58,8 @@ GURL GURLWithNSURL(NSURL* url) {
+   // to avoid encoding issues.
    // TODO(crbug.com/523200130): Remove this workaround when the minimum
    // deployment target is iOS 27.0 or higher.
 -  if (!@available(anyAppleOS 27.0, *)) {
@@ -11,7 +12,7 @@
        // The bug in NSURL absoluteString is natively fixed in iOS 27+.
 --- a/net/base/apple/url_conversions_unittest.mm
 +++ b/net/base/apple/url_conversions_unittest.mm
-@@ -255,7 +255,8 @@ TEST_F(URLConversionTest, TestGURLWithNSURLFeatureDisabled) {
+@@ -255,7 +255,8 @@ TEST_F(URLConversionTest, TestGURLWithNS
    NSURL* url = [NSURL URLWithString:@"about:blank#hash"];
    GURL gurl = GURLWithNSURL(url);
  

--- a/patches/ungoogled-chromium/macos/fix-build-without-crubit.patch
+++ b/patches/ungoogled-chromium/macos/fix-build-without-crubit.patch
@@ -1,0 +1,29 @@
+--- a/components/cbor/BUILD.gn
++++ b/components/cbor/BUILD.gn
+@@ -12,7 +12,7 @@ buildflag_header("buildflags") {
+   # TODO(crbug.com/535682335): Remove `USE_CBOR_RUST` buildflag entirely,
+   # unconditionally enable Rust CBOR parser, and drop `is_cronet_build` check
+   # once Cronet supports Crubit dependencies.
+-  flags = [ "USE_CBOR_RUST=!$is_cronet_build" ]
++  flags = [ "USE_CBOR_RUST=$enable_cpp_api_from_rust" ]
+ }
+ 
+ component("cbor") {
+@@ -37,7 +37,7 @@ component("cbor") {
+     "//base",
+   ]
+ 
+-  if (!is_cronet_build) {
++  if (enable_cpp_api_from_rust) {
+     public_deps = [
+       "//build/rust/crubit",
+       "//components/cbor/rust:cbor_rust_bindings",
+@@ -63,7 +63,7 @@ source_set("unit_tests") {
+     "//testing/gtest",
+     "//third_party/fuzztest",
+   ]
+-  if (!is_cronet_build) {
++  if (enable_cpp_api_from_rust) {
+     deps += [ "//components/cbor/rust:cbor_rust_unittests" ]
+   }
+ 

--- a/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
+++ b/patches/ungoogled-chromium/macos/fix-disabling-safebrowsing.patch
@@ -2,7 +2,7 @@
 
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
-@@ -870,9 +870,6 @@ source_set("extensions") {
+@@ -874,9 +874,6 @@ source_set("extensions") {
        # TODO(crbug.com/346472679): Remove this circular dependency.
        "//chrome/browser/web_applications/extensions",
  
@@ -12,7 +12,7 @@
        # TODO(crbug.com/343037853): Remove this circular dependency.
        "//chrome/browser/themes",
  
-@@ -904,7 +901,6 @@ source_set("extensions") {
+@@ -908,7 +905,6 @@ source_set("extensions") {
        "//chrome/common",
        "//chrome/common/extensions/api",
        "//components/omnibox/browser",
@@ -22,7 +22,7 @@
        "//content/public/browser",
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -847,18 +847,8 @@ static_library("ui") {
+@@ -869,18 +869,8 @@ static_library("ui") {
      "//components/reading_list/core",
      "//components/renderer_context_menu",
      "//components/resources",
@@ -41,7 +41,7 @@
      "//components/schema_org/common:improved_mojom",
      "//components/search_engines",
      "//components/security_interstitials/content:security_interstitial_page",
-@@ -5607,7 +5597,6 @@ group("ui_public_dependencies") {
+@@ -5264,7 +5254,6 @@ group("ui_public_dependencies") {
      "//components/dom_distiller/core",
      "//components/enterprise/buildflags",
      "//components/paint_preview/buildflags",
@@ -64,7 +64,7 @@
        "obfuscated_archive_analysis_delegate.cc",
 --- a/chrome/browser/policy/configuration_policy_handler_list_factory.cc
 +++ b/chrome/browser/policy/configuration_policy_handler_list_factory.cc
-@@ -2454,22 +2454,6 @@ const PolicyToPreferenceMapEntry kSimple
+@@ -2466,22 +2466,6 @@ const PolicyToPreferenceMapEntry kSimple
      base::Value::Type::BOOLEAN },
  #endif
  
@@ -89,7 +89,7 @@
      ash::prefs::kAuthenticationFlowAutoReloadInterval,
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -6737,8 +6737,6 @@ test("unit_tests") {
+@@ -6109,8 +6109,6 @@ test("unit_tests") {
        "//chrome/browser/mac:unit_tests",
        "//chrome/browser/renderer_host:history_swiper",
        "//chrome/common/notifications",
@@ -100,7 +100,7 @@
        "//chrome/utility/safe_browsing",
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
-@@ -8424,33 +8424,6 @@ bool ChromeContentBrowserClient::SetupEm
+@@ -8360,33 +8360,6 @@ bool ChromeContentBrowserClient::SetupEm
      CHECK(!soda_language_pack_path.empty());
      CHECK(serializer->SetParameter(sandbox::policy::kParamSodaLanguagePackPath,
                                     soda_language_pack_path.value()));

--- a/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
+++ b/patches/ungoogled-chromium/macos/revert-v8-sanitizer-changes.patch
@@ -1,6 +1,6 @@
 --- a/v8/BUILD.gn
 +++ b/v8/BUILD.gn
-@@ -1947,6 +1947,32 @@ config("always_turbofanimize") {
+@@ -1975,6 +1975,32 @@ config("always_turbofanimize") {
    }
  }
  
@@ -35,7 +35,7 @@
  #
 --- a/v8/gni/v8.gni
 +++ b/v8/gni/v8.gni
-@@ -405,6 +405,7 @@ v8_add_configs = [
+@@ -401,6 +401,7 @@ v8_add_configs = [
    v8_path_prefix + ":features",
    v8_path_prefix + ":toolchain",
    v8_path_prefix + ":strict_warnings",

--- a/patches/ungoogled-chromium/macos/set-rustc-nightly-capability.patch
+++ b/patches/ungoogled-chromium/macos/set-rustc-nightly-capability.patch
@@ -1,6 +1,6 @@
 --- a/build/config/rust.gni
 +++ b/build/config/rust.gni
-@@ -140,7 +140,7 @@ use_chromium_rust_toolchain = rust_sysro
+@@ -128,7 +128,7 @@ use_chromium_rust_toolchain = rust_sysro
  # `rustc_nightly_capability = false` will make the build avoid the use of
  # Rust nightly features. There are no bots that test this and there is no
  # guarantee it will work, but we accept patches for this configuration.

--- a/sign_and_package_app.sh
+++ b/sign_and_package_app.sh
@@ -3,10 +3,12 @@
 set -euo pipefail
 
 _root_dir="$(dirname "$(greadlink -f "$0")")"
-_app="out/Default/Chromium.app"
+_src_dir="${CHROMIUM_SRC_DIR:-$_root_dir/build/src}"
+_app="$_src_dir/out/Default/Chromium.app"
 _framework="$_app/Contents/Frameworks/Chromium Framework.framework"
 _helpers="$_framework/Helpers"
 _libraries="$_framework/Libraries"
+_pkg_dmg="$_src_dir/chrome/installer/mac/pkg-dmg"
 
 _ad_hoc="${MACOS_AD_HOC_SIGNING:-0}"
 _target_dmg="${1:-}"
@@ -45,10 +47,15 @@ sign --identifier io.ungoogled-software.ungoogled-chromium.helper --options rest
 sign --identifier io.ungoogled-software.ungoogled-chromium.framework.AlertNotificationService --options restrict,library,runtime,kill "$_helpers/Chromium Helper (Alerts).app"
 sign --identifier app_mode_loader --options restrict,library,runtime,kill "$_helpers/app_mode_loader"
 sign --identifier web_app_shortcut_copier --options restrict,library,runtime,kill "$_helpers/web_app_shortcut_copier"
-sign --identifier libEGL "$_libraries/libEGL.dylib"
-sign --identifier libGLESv2 "$_libraries/libGLESv2.dylib"
-sign --identifier libvk_swiftshader "$_libraries/libvk_swiftshader.dylib"
-sign --identifier libvulkan "$_libraries/libvulkan.dylib"
+
+# The dylibs bundled by Chromium vary by release. Sign the files that are
+# actually present instead of maintaining a version-dependent hard-coded list.
+for _dylib in "$_libraries"/*.dylib; do
+  [[ -e "$_dylib" ]] || continue
+  _dylib_name="$(basename "$_dylib" .dylib)"
+  sign --identifier "$_dylib_name" "$_dylib"
+done
+
 sign --identifier io.ungoogled-software.ungoogled-chromium.framework "$_framework"
 if (( _ad_hoc )); then
   sign --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements "$_root_dir/entitlements/app-entitlements.plist" "$_app"
@@ -151,7 +158,7 @@ else
 fi
 
 # Package the app
-chrome/installer/mac/pkg-dmg \
+"$_pkg_dmg" \
   --sourcefile --source "$_app" \
   --target "$_target_dmg" \
   --volname Chromium --symlink /Applications:/Applications \

--- a/sign_and_package_app.sh
+++ b/sign_and_package_app.sh
@@ -1,72 +1,158 @@
 #!/usr/bin/env bash
 
-set -eo pipefail
+set -euo pipefail
 
 _root_dir="$(dirname "$(greadlink -f "$0")")"
+_app="out/Default/Chromium.app"
+_framework="$_app/Contents/Frameworks/Chromium Framework.framework"
+_helpers="$_framework/Helpers"
+_libraries="$_framework/Libraries"
 
-# For packaging
-_chromium_version=$(cat "$_root_dir"/ungoogled-chromium/chromium_version.txt)
-_ungoogled_revision=$(cat "$_root_dir"/ungoogled-chromium/revision.txt)
-_package_revision=$(cat "$_root_dir"/revision.txt)
+_ad_hoc="${MACOS_AD_HOC_SIGNING:-0}"
+_target_dmg="${1:-}"
+if [[ -z "$_target_dmg" ]]; then
+  _chromium_version="$(cat "$_root_dir/ungoogled-chromium/chromium_version.txt")"
+  _ungoogled_revision="$(cat "$_root_dir/ungoogled-chromium/revision.txt")"
+  _package_revision="$(cat "$_root_dir/revision.txt")"
+  _target_dmg="$_root_dir/build/ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_macos.dmg"
+fi
+
+sign() {
+  if (( _ad_hoc )); then
+    codesign --sign - --force "$@"
+  else
+    codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp "$@"
+  fi
+}
+
+error() {
+  printf '::error::%s\n' "$*" >&2
+}
+
+warning() {
+  printf '::warning::%s\n' "$*" >&2
+}
 
 # Fix issue where macOS requests permission for incoming network connections
 # See https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/17
-xattr -cs out/Default/Chromium.app
+xattr -cs "$_app"
 
 # Sign the binary
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier chrome_crashpad_handler --options=restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/chrome_crashpad_handler
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper.app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper.renderer --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-renderer-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Renderer\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,kill,runtime --entitlements $_root_dir/entitlements/helper-gpu-entitlements.plist out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(GPU\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework.AlertNotificationService --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/Chromium\ Helper\ \(Alerts\).app
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier app_mode_loader --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/app_mode_loader
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier web_app_shortcut_copier --options restrict,library,runtime,kill out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Helpers/web_app_shortcut_copier
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libEGL out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libEGL.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libGLESv2 out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libGLESv2.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libvk_swiftshader out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libvk_swiftshader.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier libvulkan out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework/Libraries/libvulkan.dylib
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium.framework out/Default/Chromium.app/Contents/Frameworks/Chromium\ Framework.framework
-codesign --sign "$MACOS_CERTIFICATE_NAME" --force --timestamp --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements $_root_dir/entitlements/app-entitlements.plist --requirements '=designated => identifier "io.ungoogled-software.ungoogled-chromium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */' out/Default/Chromium.app
+sign --identifier chrome_crashpad_handler --options=restrict,library,runtime,kill "$_helpers/chrome_crashpad_handler"
+sign --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,library,runtime,kill "$_helpers/Chromium Helper.app"
+sign --identifier io.ungoogled-software.ungoogled-chromium.helper.renderer --options restrict,kill,runtime --entitlements "$_root_dir/entitlements/helper-renderer-entitlements.plist" "$_helpers/Chromium Helper (Renderer).app"
+sign --identifier io.ungoogled-software.ungoogled-chromium.helper --options restrict,kill,runtime --entitlements "$_root_dir/entitlements/helper-gpu-entitlements.plist" "$_helpers/Chromium Helper (GPU).app"
+sign --identifier io.ungoogled-software.ungoogled-chromium.framework.AlertNotificationService --options restrict,library,runtime,kill "$_helpers/Chromium Helper (Alerts).app"
+sign --identifier app_mode_loader --options restrict,library,runtime,kill "$_helpers/app_mode_loader"
+sign --identifier web_app_shortcut_copier --options restrict,library,runtime,kill "$_helpers/web_app_shortcut_copier"
+sign --identifier libEGL "$_libraries/libEGL.dylib"
+sign --identifier libGLESv2 "$_libraries/libGLESv2.dylib"
+sign --identifier libvk_swiftshader "$_libraries/libvk_swiftshader.dylib"
+sign --identifier libvulkan "$_libraries/libvulkan.dylib"
+sign --identifier io.ungoogled-software.ungoogled-chromium.framework "$_framework"
+if (( _ad_hoc )); then
+  sign --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements "$_root_dir/entitlements/app-entitlements.plist" "$_app"
+else
+  sign --identifier io.ungoogled-software.ungoogled-chromium --options restrict,library,runtime,kill --entitlements "$_root_dir/entitlements/app-entitlements.plist" --requirements '=designated => identifier "io.ungoogled-software.ungoogled-chromium" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */' "$_app"
+fi
 
 # Verify the binary signature
-codesign --verify --deep --verbose=4 out/Default/Chromium.app
+verify_dylib() {
+  local dylib="$1"
+  local signature_info
 
-# Pepare app notarization
-ditto -c -k --keepParent "out/Default/Chromium.app" "notarize.zip"
+  codesign --verify --strict --verbose=4 "$dylib"
 
-# Notarize the app
-xcrun notarytool store-credentials "notarytool-profile" --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID" --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID" --password "$PROD_MACOS_NOTARIZATION_PWD"
-notary_submit_output="$(xcrun notarytool submit "notarize.zip" --keychain-profile "notarytool-profile" --wait --output-format json)"
-notary_status="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("status",""))' <<< "$notary_submit_output")"
-notary_submission_id="$(python3 -c 'import json,sys; print(json.load(sys.stdin).get("id",""))' <<< "$notary_submit_output")"
-
-if [[ "$notary_status" != "Accepted" ]]; then
-  echo "Notarization submission was not accepted (status: ${notary_status:-unknown})."
-  if [[ -n "$notary_submission_id" ]]; then
-    echo "Fetching notarization log for submission $notary_submission_id..."
-    xcrun notarytool log "$notary_submission_id" --keychain-profile "notarytool-profile" || true
+  if (( _ad_hoc )); then
+    return
   fi
-  exit 1
-fi
 
-if ! xcrun stapler staple "out/Default/Chromium.app"; then
-  echo "Stapling failed."
-  if [[ -n "$notary_submission_id" ]]; then
-    echo "Fetching notarization log for submission $notary_submission_id..."
-    xcrun notarytool log "$notary_submission_id" --keychain-profile "notarytool-profile" || true
+  signature_info="$(codesign -dvvv "$dylib" 2>&1)"
+  printf '%s\n' "$signature_info"
+
+  if ! grep -q '^Authority=Developer ID Application:' <<< "$signature_info"; then
+    error "${dylib} is not signed with a Developer ID Application certificate"
+    return 1
   fi
-  exit 1
+
+  if ! grep -q '^Timestamp=' <<< "$signature_info"; then
+    error "${dylib} does not have a secure signing timestamp"
+    return 1
+  fi
+}
+
+# Check all framework dylibs to catch signing omissions in future releases.
+for _framework_dylib in "$_libraries"/*.dylib; do
+  verify_dylib "$_framework_dylib"
+done
+
+codesign --verify --deep --strict --verbose=4 "$_app"
+
+notarize_app() {
+  local archive="$TMPDIR/notarize.zip"
+  local result="$TMPDIR/notary-result.json"
+  local log="$TMPDIR/notary-log.json"
+  local status submission_id
+  local submit_exit=0
+  local credentials=(
+    --apple-id "$PROD_MACOS_NOTARIZATION_APPLE_ID"
+    --team-id "$PROD_MACOS_NOTARIZATION_TEAM_ID"
+    --password "$PROD_MACOS_NOTARIZATION_PWD"
+  )
+
+  ditto -c -k --keepParent "$_app" "$archive"
+
+  xcrun notarytool submit --wait --output-format json "${credentials[@]}" "$archive" \
+    > "$result" || submit_exit=$?
+
+  cat "$result"
+
+  status="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("status", ""))' "$result" 2>/dev/null)" || status=""
+  submission_id="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("id", ""))' "$result" 2>/dev/null)" || submission_id=""
+
+  if [[ -n "$submission_id" ]]; then
+    if xcrun notarytool log "${credentials[@]}" "$submission_id" > "$log"; then
+      cat "$log"
+    else
+      warning "Could not retrieve Apple's notarization log for submission $submission_id"
+      [[ ! -s "$log" ]] || cat "$log" || true
+    fi
+  fi
+
+  if [[ "$status" != "Accepted" ]]; then
+    if [[ -n "$status" ]]; then
+      error "Apple notarization failed with status: $status"
+    elif (( submit_exit != 0 )); then
+      error "notarytool submit failed with exit status $submit_exit"
+    else
+      error "Apple notarization returned no status"
+    fi
+    return 1
+  fi
+
+  if (( submit_exit != 0 )); then
+    error "notarytool submit exited with status $submit_exit despite reporting Accepted"
+    return "$submit_exit"
+  fi
+
+  if [[ -z "$submission_id" ]]; then
+    error "Apple notarization returned Accepted without a submission ID"
+    return 1
+  fi
+
+  xcrun stapler staple "$_app"
+  xcrun stapler validate "$_app"
+}
+
+if (( _ad_hoc )); then
+  printf 'Ad-hoc signing enabled; skipping notarization and stapling.\n'
+else
+  notarize_app
 fi
-
-xcrun stapler validate "out/Default/Chromium.app"
-
-# If you do not have an Apple Developer account to notarize the app, or you do not want to notarize the app
-# comment the lines above and uncomment the following line to use ad-hoc signing.
-# codesign --force --deep --sign - out/Default/Chromium.app
 
 # Package the app
 chrome/installer/mac/pkg-dmg \
-  --sourcefile --source out/Default/Chromium.app \
-  --target "$_root_dir/build/ungoogled-chromium_${_chromium_version}-${_ungoogled_revision}.${_package_revision}_macos.dmg" \
+  --sourcefile --source "$_app" \
+  --target "$_target_dmg" \
   --volname Chromium --symlink /Applications:/Applications \
   --format UDBZ --verbosity 2


### PR DESCRIPTION
Notes:

- Submodule is bumped.
- Patches are refreshed.
- New patch is added for building without Crubit (https://github.com/ungoogled-software/ungoogled-chromium/pull/3928 build note 1).
- Patch is updated for building without flags `no-lifetime-safety-inference` and `no-experimental-lifetime-safety-tu-analysis` (https://github.com/ungoogled-software/ungoogled-chromium/pull/3928 build note 3).
- Notarization process is updated again to unify local and CI build process and retire hardcoded dynamic library paths.

---

Builds and runs fine locally.

<img width="711" height="189" alt="image" src="https://github.com/user-attachments/assets/6ceb8875-854f-4a59-91c8-ccd171696be8" />

Notarization verified on local build.

```
╰─ ◎ spctl -a -vvv -t install /Applications/Chromium.app
/Applications/Chromium.app: accepted
source=Notarized Developer ID
origin=Developer ID Application: Qian Qian (B9A88FL5XJ)
```